### PR TITLE
modified start date

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -530,7 +530,7 @@ def main_impl():
             select_fields_by_default=CONFIG.get("select_fields_by_default"),
             default_start_date=CONFIG.get("start_date"),
             api_type=CONFIG.get("api_type"),
-            limit_tasks_month=CONFIG.get("limit_tasks_month"),
+            limit_windowed_objects_month=CONFIG.get("limit_windowed_objects_month"),
             pull_config_objects=CONFIG.get("OBJECTS"),
         )
         sf.login()

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -217,6 +217,8 @@ def field_to_property_schema(field, mdata):  # noqa: C901
 
 
 class Salesforce:
+    WINDOWED_OBJECTS = {"Task", "Campaign", "CampaignMember"}
+
     # pylint: disable=too-many-instance-attributes,too-many-arguments
     def __init__(
         self,
@@ -228,7 +230,8 @@ class Salesforce:
         select_fields_by_default=None,
         default_start_date=None,
         api_type=None,
-        limit_tasks_month=None,
+        windowed_objects=None,
+        limit_windowed_objects_month=None,
         pull_config_objects=None,
     ):
         self.api_type = api_type.upper() if api_type else None
@@ -254,7 +257,8 @@ class Salesforce:
         self._initial_quota_allotted = None
         self._latest_quota_used = None
         self._latest_quota_allotted = None
-        self.limit_tasks_month = limit_tasks_month
+        self.windowed_objects = set(windowed_objects) if windowed_objects else self.WINDOWED_OBJECTS
+        self.limit_windowed_objects_month = limit_windowed_objects_month
         self.pull_config_objects = pull_config_objects
 
         self.auth = SalesforceAuth.from_credentials(credentials, is_sandbox=self.is_sandbox)
@@ -469,22 +473,21 @@ class Salesforce:
             singer.get_bookmark(state, catalog_entry["tap_stream_id"], replication_key) or self.default_start_date
         )
 
-        # Apply task month limit if this is a Task stream and limit is configured
+        # Apply windowed objects month limit if this stream is in windowed_objects and limit is configured
         if (
-            catalog_entry["tap_stream_id"] == "Task"
-            and self.limit_tasks_month is not None
-            and self.limit_tasks_month > 0
+            catalog_entry["tap_stream_id"] in self.windowed_objects
+            and self.limit_windowed_objects_month is not None
+            and self.limit_windowed_objects_month > 0
         ):
-            # Calculate the earliest allowed date (limit_tasks_month ago from now)
             now = singer_utils.now()
-            month_limit_date = now - timedelta(days=31 * self.limit_tasks_month)
+            month_limit_date = now - timedelta(days=31 * self.limit_windowed_objects_month)
             month_limit_date_str = month_limit_date.isoformat()
 
-            # Use the later of the two dates (bookmark/default vs month limit)
             if start_date < month_limit_date_str:
                 LOGGER.info(
-                    "Task stream limited to %d months. Using start date %s instead of %s",
-                    self.limit_tasks_month,
+                    "%s stream limited to %d months. Using start date %s instead of %s",
+                    catalog_entry["tap_stream_id"],
+                    self.limit_windowed_objects_month,
                     month_limit_date_str,
                     start_date,
                 )

--- a/tests/test_windowed_objects_refactor.py
+++ b/tests/test_windowed_objects_refactor.py
@@ -1,0 +1,195 @@
+"""Unit tests for the windowed-objects-refactor changes.
+
+Changes covered:
+- limit_tasks_month renamed to limit_windowed_objects_month
+- WINDOWED_OBJECTS class constant: Task, Campaign, CampaignMember
+- get_start_date() caps all three windowed streams (previously Task only)
+- Non-windowed streams (Lead, Contact, Account, Opportunity, User) use full history
+
+Run with:
+    pytest tests/test_windowed_objects_refactor.py -v
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from singer import metadata as singer_metadata
+from singer import utils as singer_utils
+
+from tap_salesforce.salesforce import Salesforce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_sf(default_start_date="2000-01-01T00:00:00Z", limit_windowed_objects_month=None):
+    """Build a minimal Salesforce instance without network calls."""
+    sf = Salesforce.__new__(Salesforce)
+    sf.windowed_objects = Salesforce.WINDOWED_OBJECTS
+    sf.limit_windowed_objects_month = limit_windowed_objects_month
+    sf.pull_config_objects = None
+    sf.default_start_date = (
+        singer_utils.strptime_to_utc(default_start_date).isoformat()
+    )
+    return sf
+
+
+def make_catalog_entry(stream_id, replication_key="SystemModstamp"):
+    """Build a minimal Singer catalog entry."""
+    mdata = singer_metadata.new()
+    singer_metadata.write(mdata, (), "replication-key", replication_key)
+    return {
+        "stream": stream_id,
+        "tap_stream_id": stream_id,
+        "metadata": singer_metadata.to_list(mdata),
+    }
+
+
+def empty_state():
+    return {}
+
+
+def state_with_bookmark(stream, date):
+    return {"bookmarks": {stream: {"SystemModstamp": date}}}
+
+
+# ---------------------------------------------------------------------------
+# 1. WINDOWED_OBJECTS class constant
+# ---------------------------------------------------------------------------
+
+class TestWindowedObjectsConstant:
+    def test_windowed_objects_is_exactly_task_campaign_campaignmember(self):
+        assert Salesforce.WINDOWED_OBJECTS == {"Task", "Campaign", "CampaignMember"}
+
+    def test_non_windowed_streams_not_in_constant(self):
+        for stream in ["Lead", "Contact", "Account", "Opportunity", "User"]:
+            assert stream not in Salesforce.WINDOWED_OBJECTS
+
+
+# ---------------------------------------------------------------------------
+# 2. Config key rename: limit_tasks_month → limit_windowed_objects_month
+# ---------------------------------------------------------------------------
+
+class TestConfigKeyRename:
+    def test_limit_windowed_objects_month_stored_on_instance(self):
+        sf = make_sf(limit_windowed_objects_month=9)
+        assert sf.limit_windowed_objects_month == 9
+
+    def test_limit_windowed_objects_month_none_by_default(self):
+        sf = make_sf()
+        assert sf.limit_windowed_objects_month is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Default start_date is 2000-01-01 (was 2025-01-01 on main)
+# ---------------------------------------------------------------------------
+
+class TestDefaultStartDate:
+    def test_default_start_date_is_year_2000(self):
+        sf = make_sf()
+        assert sf.default_start_date.startswith("2000-01-01")
+
+    @pytest.mark.parametrize("stream", ["Lead", "Contact", "Account", "Opportunity", "User"])
+    def test_full_history_streams_use_2000_start_date(self, stream):
+        """Non-windowed streams fall back to 2000-01-01 with no bookmark."""
+        sf = make_sf(limit_windowed_objects_month=9)
+        result = sf.get_start_date(empty_state(), make_catalog_entry(stream))
+        assert result.startswith("2000-01-01"), (
+            f"{stream} should use full history start date 2000-01-01, got {result}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Windowed streams get capped (Task, Campaign, CampaignMember)
+# ---------------------------------------------------------------------------
+
+class TestWindowedStreamsCapped:
+    @pytest.mark.parametrize("stream", ["Task", "Campaign", "CampaignMember"])
+    def test_old_start_date_is_capped_to_9_months(self, stream):
+        """A 2000-01-01 bookmark/default for windowed streams must be capped to ~9 months ago."""
+        sf = make_sf(limit_windowed_objects_month=9)
+        state = state_with_bookmark(stream, "2000-01-01T00:00:00+00:00")
+        result = sf.get_start_date(state, make_catalog_entry(stream))
+        assert not result.startswith("2000"), (
+            f"{stream} with old bookmark should be capped, got {result}"
+        )
+
+    @pytest.mark.parametrize("stream", ["Task", "Campaign", "CampaignMember"])
+    def test_recent_bookmark_is_not_capped(self, stream):
+        """A recent bookmark within the window must not be altered."""
+        recent = (singer_utils.now() - timedelta(days=30)).isoformat()
+        sf = make_sf(limit_windowed_objects_month=9)
+        state = state_with_bookmark(stream, recent)
+        result = sf.get_start_date(state, make_catalog_entry(stream))
+        assert result == recent, (
+            f"{stream} recent bookmark should not be capped, got {result}"
+        )
+
+    @pytest.mark.parametrize("stream", ["Task", "Campaign", "CampaignMember"])
+    def test_cap_is_approximately_9_months_ago(self, stream):
+        """The capped date must be within a day of (now - 9 * 31 days)."""
+        sf = make_sf(limit_windowed_objects_month=9)
+        state = state_with_bookmark(stream, "2000-01-01T00:00:00+00:00")
+        result = sf.get_start_date(state, make_catalog_entry(stream))
+
+        expected_floor = singer_utils.now() - timedelta(days=31 * 9)
+        result_dt = singer_utils.strptime_to_utc(result)
+        diff = abs((result_dt - expected_floor).total_seconds())
+        assert diff < 86400, (
+            f"Cap date {result} should be ~9 months ago, diff={diff}s"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Non-windowed streams are NOT capped even with limit set
+# ---------------------------------------------------------------------------
+
+class TestNonWindowedStreamsNotCapped:
+    @pytest.mark.parametrize("stream", ["Lead", "Contact", "Account", "Opportunity", "User"])
+    def test_full_history_streams_are_never_capped(self, stream):
+        sf = make_sf(limit_windowed_objects_month=9)
+        state = state_with_bookmark(stream, "2000-01-01T00:00:00+00:00")
+        result = sf.get_start_date(state, make_catalog_entry(stream))
+        assert result.startswith("2000-01-01"), (
+            f"{stream} should not be capped, got {result}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Cap is disabled when limit is None or 0
+# ---------------------------------------------------------------------------
+
+class TestCapDisabledWhenNoLimit:
+    @pytest.mark.parametrize("limit", [None, 0])
+    @pytest.mark.parametrize("stream", ["Task", "Campaign", "CampaignMember"])
+    def test_no_cap_when_limit_is_none_or_zero(self, stream, limit):
+        sf = make_sf(limit_windowed_objects_month=limit)
+        state = state_with_bookmark(stream, "2000-01-01T00:00:00+00:00")
+        result = sf.get_start_date(state, make_catalog_entry(stream))
+        assert result.startswith("2000-01-01"), (
+            f"{stream} should not be capped when limit={limit}, got {result}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Bookmark takes priority over default start_date
+# ---------------------------------------------------------------------------
+
+class TestBookmarkPriority:
+    @pytest.mark.parametrize("stream", ["Lead", "Contact", "Account", "Opportunity", "User"])
+    def test_bookmark_used_over_default_for_full_history_streams(self, stream):
+        bookmark = "2025-06-01T00:00:00Z"
+        sf = make_sf(limit_windowed_objects_month=9)
+        state = state_with_bookmark(stream, bookmark)
+        result = sf.get_start_date(state, make_catalog_entry(stream))
+        assert result == bookmark
+
+    @pytest.mark.parametrize("stream", ["Task", "Campaign", "CampaignMember"])
+    def test_recent_bookmark_used_over_cap_for_windowed_streams(self, stream):
+        recent_bookmark = (singer_utils.now() - timedelta(days=10)).isoformat()
+        sf = make_sf(limit_windowed_objects_month=9)
+        state = state_with_bookmark(stream, recent_bookmark)
+        result = sf.get_start_date(state, make_catalog_entry(stream))
+        assert result == recent_bookmark


### PR DESCRIPTION
Below are the changes done 
mk-data-ingestion-core
| Field | Change |
|------|--------|
| start_date | 2025-01-01 → 2000-01-01 |
| config_key | limit_tasks_month → limit_windowed_objects_month |
| window_months | 12 → 9 |
| objects | no change |

mk-tap-salesforce
| Field             | Change |
|-------------------|--------|
| config_key        | limit_tasks_month → limit_windowed_objects_month |
| windowed_objects  | Task → Task, Campaign, CampaignMember |
| get_start_date    | Task only → all windowed objects |

https://hgdata.atlassian.net/browse/RGI-765