### PR TITLE
feat: add support for login url overrides for simulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,14 @@ To sync data, select fields in the `properties.json` output and run the tap.
 tap-salesforce --config config.json --properties properties.json [--state state.json]
 ```
 
+## Environment Variables
+
+### `SIMULATOR_TAP_SALESFORCE_LOGIN_URL` (dev only)
+
+Optional override for the Salesforce OAuth token endpoint. When set, the tap POSTs the OAuth refresh request to this URL instead of `https://login.salesforce.com/services/oauth2/token` (or `https://test.salesforce.com/...` when `is_sandbox=true`). Read directly from the process environment in `tap_salesforce/salesforce/credentials.py`; not a `config.json` setting.
+
+This variable is injected externally — it is not normally set by the tap or its callers. In MK's data ingestion pipeline it is supplied by `mk-airflow` (`dags/data_ingestion_core.py:_apply_simulator_overrides`), which reads the `mdi_simulator_overrides` MWAA Airflow Variable and writes the resulting env vars into the pull task's ECS `containerOverrides`. That injection is gated behind `env == "dev"`, so the variable is never set on production pull tasks. When unset (the default everywhere outside the dev MWAA), the tap behaves identically to upstream.
+
+Intended use is to redirect a tenant's pull task at a local Salesforce simulator (`rgip-connector-simulators`) for integration testing without touching production credentials.
+
 Copyright &copy; 2017 Stitch

--- a/tap_salesforce/salesforce/credentials.py
+++ b/tap_salesforce/salesforce/credentials.py
@@ -70,6 +70,12 @@ class SalesforceAuthOAuth(SalesforceAuth):
 
     @property
     def _login_url(self):
+        # Simulator override env var for login URL
+        import os
+        override = os.environ.get("SIMULATOR_TAP_SALESFORCE_LOGIN_URL")
+        if override:
+            return override
+
         login_url = "https://login.salesforce.com/services/oauth2/token"
 
         if self.is_sandbox:


### PR DESCRIPTION
This pull request introduces an environment variable override for the Salesforce login URL in the `tap_salesforce/salesforce/credentials.py` file. This allows the login URL to be dynamically set to allow the tap access to our salesforce simulators.

Authentication and configuration improvements:

* Added support for overriding the Salesforce login URL using the `SIMULATOR_TAP_SALESFORCE_LOGIN_URL` environment variable in the `_login_url` property of the credentials class.