### PR TITLE
Handled UNKNOWN_EXCEPTION:Numeric Overflow with per-Id row skip

### DIFF
--- a/tap_salesforce/salesforce/rest.py
+++ b/tap_salesforce/salesforce/rest.py
@@ -9,6 +9,36 @@ from tap_salesforce.salesforce.exceptions import TapSalesforceExceptionError
 LOGGER = singer.get_logger()
 
 MAX_RETRIES = 8
+# Bisection bottom: any smaller range and we fall through to per-Id isolation
+# (for 'isolate' errors) or raise (for 'bisect' errors).
+MIN_BISECT_SECONDS = 3600
+# Errors recoverable by date-range bisection alone.
+_BISECT_ERROR_CODES = {"QUERY_TIMEOUT", "OPERATION_TOO_LARGE"}
+
+
+def _classify_error(response):
+    """Classify a Salesforce REST error body returned alongside an HTTPError.
+
+    Returns one of:
+      - "bisect"  : recoverable by halving the date range (QUERY_TIMEOUT,
+                    OPERATION_TOO_LARGE).
+      - "isolate" : cannot be fixed by bisection alone — a specific row's
+                    formula field overflows during serialisation. Bisecting
+                    narrows the offending window, then per-Id isolation skips
+                    the bad row(s). Specifically catches
+                    UNKNOWN_EXCEPTION:"Numeric Overflow".
+      - None      : not recoverable here; caller should re-raise.
+    """
+    if not isinstance(response, list) or not response:
+        return None
+    err = response[0]
+    code = err.get("errorCode")
+    msg = (err.get("message") or "").strip()
+    if code in _BISECT_ERROR_CODES:
+        return "bisect"
+    if code == "UNKNOWN_EXCEPTION" and "Numeric Overflow" in msg:
+        return "isolate"
+    return None
 
 
 class Rest:
@@ -22,7 +52,8 @@ class Rest:
         return self._query_recur(query, catalog_entry, start_date)
 
     # pylint: disable=too-many-arguments
-    def _query_recur(self, query, catalog_entry, start_date_str, end_date=None, retries=MAX_RETRIES):
+    def _query_recur(self, query, catalog_entry, start_date_str, end_date=None,
+                     retries=MAX_RETRIES, isolate_mode=False):
         params = {"q": query}
         # Use query endpoint for Task to exclude soft-deleted records (prevents OPERATION_TOO_LARGE)
         # Use queryAll for other objects to preserve soft-deleted records
@@ -45,7 +76,8 @@ class Rest:
                 "Ran out of retries attempting to query Salesforce Object {}".format(catalog_entry["stream"])
             )
 
-        retryable = False
+        # None | "bisect" | "isolate"
+        error_class = None
         # Track the last replication-key value yielded so that if pagination fails
         # mid-stream we can resume from that point instead of re-querying from the
         # original start date (which would re-yield already-streamed records).
@@ -66,27 +98,34 @@ class Rest:
 
         except HTTPError as ex:
             response = ex.response.json()
-            if isinstance(response, list) and response[0].get("errorCode") in ("QUERY_TIMEOUT", "OPERATION_TOO_LARGE"):
-                start_date = singer_utils.strptime_with_tz(start_date_str)
-                total_seconds = (end_date - start_date).total_seconds()
-                end_date_str = singer_utils.strftime(end_date)
-                if total_seconds >= 86400:
-                    range_label = f"{int(total_seconds // 86400)} days"
-                else:
-                    range_label = f"{total_seconds / 3600:.1f} hours"
-                LOGGER.info(
-                    "Salesforce returned %s querying %s of %s (range: %s to %s) — bisecting date range",
-                    response[0].get("errorCode"),
-                    range_label,
-                    catalog_entry["stream"],
-                    start_date_str,
-                    end_date_str,
-                )
-                retryable = True
-            else:
+            error_class = _classify_error(response)
+            if error_class is None:
                 raise ex
+            start_date = singer_utils.strptime_with_tz(start_date_str)
+            total_seconds = (end_date - start_date).total_seconds()
+            end_date_str = singer_utils.strftime(end_date)
+            if total_seconds >= 86400:
+                range_label = f"{int(total_seconds // 86400)} days"
+            else:
+                range_label = f"{total_seconds / 3600:.1f} hours"
+            LOGGER.info(
+                "Salesforce returned %s querying %s of %s (range: %s to %s) — will %s",
+                response[0].get("errorCode"),
+                range_label,
+                catalog_entry["stream"],
+                start_date_str,
+                end_date_str,
+                ("bisect date range" if error_class == "bisect"
+                 else "bisect then isolate per-Id if needed"),
+            )
 
-        if retryable:
+        if error_class is not None:
+            # Carry isolate_mode forward through recursion once we've seen a
+            # Numeric Overflow — even if a later sub-range surfaces a different
+            # bisect-able error, we still want to fall through to per-Id mode
+            # at the bottom rather than raising.
+            next_isolate_mode = isolate_mode or (error_class == "isolate")
+
             if last_seen_replication_value is not None:
                 # Partial pagination: some records were already streamed to the target
                 # before the error. Re-querying from start_date_str would duplicate them.
@@ -104,27 +143,122 @@ class Rest:
                     singer_utils.strftime(end_date) if end_date < sync_start else None,
                 )
                 for record in self._query_recur(
-                    resume_query, catalog_entry, last_seen_replication_value, end_date, retries - 1
+                    resume_query, catalog_entry, last_seen_replication_value, end_date,
+                    retries - 1, isolate_mode=next_isolate_mode,
                 ):
                     yield record
             else:
                 # No records were yielded yet — safe to bisect the full range.
                 start_date = singer_utils.strptime_with_tz(start_date_str)
                 half_range = (end_date - start_date) // 2
-                end_date = end_date - half_range
 
-                if half_range.total_seconds() < 3600:
+                if half_range.total_seconds() < MIN_BISECT_SECONDS:
+                    # Bisect bottomed out. For 'bisect' errors that's an infinite
+                    # loop — raise as before. For 'isolate' (Numeric Overflow)
+                    # switch to per-Id mode: bad row(s) get skipped, the rest
+                    # stream cleanly.
+                    if next_isolate_mode:
+                        for record in self._sync_isolated_rows(
+                            catalog_entry,
+                            start_date_str,
+                            singer_utils.strftime(end_date),
+                        ):
+                            yield record
+                        return
                     raise TapSalesforceExceptionError(
                         "Attempting to query by less than 1 hour range, this would cause infinite looping."
                     )
 
+                end_date = end_date - half_range
                 query = self.sf._build_query_string(
                     catalog_entry,
                     singer_utils.strftime(start_date),
                     singer_utils.strftime(end_date),
                 )
-                for record in self._query_recur(query, catalog_entry, start_date_str, end_date, retries - 1):
+                for record in self._query_recur(
+                    query, catalog_entry, start_date_str, end_date,
+                    retries - 1, isolate_mode=next_isolate_mode,
+                ):
                     yield record
+
+    def _sync_isolated_rows(self, catalog_entry, start_date_str, end_date_str):
+        """Fallback for Numeric Overflow at sub-bisect-bottom windows.
+
+        When `_query_recur`'s date-range bisection has narrowed to a window
+        smaller than MIN_BISECT_SECONDS but Salesforce is still returning
+        UNKNOWN_EXCEPTION:"Numeric Overflow" (i.e. a specific row's formula
+        field overflows during serialisation), we can't shrink the window
+        further. Instead we enumerate Ids in the window with a minimal
+        projection, then re-fetch each Id alone with the full projection.
+        Rows that still overflow get logged with their Id and skipped; the
+        rest stream cleanly.
+
+        Cost: O(rows-in-window) extra REST calls (one cheap Id list + one
+        per row). With MIN_BISECT_SECONDS=3600 this is bounded.
+        """
+        stream_name = catalog_entry["stream"]
+        is_task = stream_name.lower() == "task"
+        endpoint = "query" if is_task else "queryAll"
+        url = f"{self.sf.instance_url}/services/data/v60.0/{endpoint}"
+        headers = self.sf.auth.rest_headers
+
+        catalog_meta = singer_metadata.to_map(catalog_entry.get("metadata", []))
+        replication_key = catalog_meta.get((), {}).get("replication-key") or "SystemModstamp"
+
+        # Step 1: list Ids in the offending window with minimal projection.
+        id_query = (
+            f"SELECT Id FROM {stream_name} "
+            f"WHERE {replication_key} >= {start_date_str} "
+            f"AND {replication_key} < {end_date_str} "
+            f"ORDER BY {replication_key} ASC"
+        )
+        LOGGER.info(
+            "isolate-mode: enumerating Ids for %s in [%s, %s)",
+            stream_name, start_date_str, end_date_str,
+        )
+        ids = [row["Id"] for row in self._sync_records(url, headers, {"q": id_query})]
+        LOGGER.info(
+            "isolate-mode: fetching %d %s rows individually",
+            len(ids), stream_name,
+        )
+
+        # Step 2: re-fetch each row alone with the full projection. Skip ones
+        # that still overflow, emit a structured ERROR log + counter metric so
+        # the platform team can chase the offending formula values.
+        skipped = 0
+        for sf_id in ids:
+            # Build the full-projection query then constrain to a single Id.
+            # `order_by_clause=False` keeps the trailing `AND Id = '...'` syntactically valid.
+            single_query = self.sf._build_query_string(
+                catalog_entry, start_date_str, end_date_str, order_by_clause=False,
+            ) + f" AND Id = '{sf_id}'"
+            try:
+                for record in self._sync_records(url, headers, {"q": single_query}):
+                    yield record
+            except HTTPError as ex:
+                response = ex.response.json()
+                if _classify_error(response) == "isolate":
+                    skipped += 1
+                    LOGGER.error(
+                        "MDI_SFDC_NUMERIC_OVERFLOW_ROW_SKIPPED stream=%s id=%s "
+                        "message=%r — row triggers Numeric Overflow during serialisation. "
+                        "Identify the offending formula field with: "
+                        "SELECT Id, <formula_field> FROM %s WHERE Id='%s'",
+                        stream_name, sf_id, response[0].get("message"),
+                        stream_name, sf_id,
+                    )
+                    # Emit a counter so the run summary + Datadog log-based metric pick it up.
+                    singer.metrics.Counter(
+                        metric="tap_salesforce_numeric_overflow_skipped",
+                        tags={"stream": stream_name},
+                    ).increment()
+                    continue
+                raise
+        if skipped:
+            LOGGER.warning(
+                "isolate-mode summary: %s — %d/%d row(s) skipped due to Numeric Overflow",
+                stream_name, skipped, len(ids),
+            )
 
     def _sync_records(self, url, headers, params):
         while True:

--- a/tests/test_numeric_overflow_skip.py
+++ b/tests/test_numeric_overflow_skip.py
@@ -1,0 +1,399 @@
+"""Tests for the Numeric Overflow row-skip path in tap_salesforce.salesforce.rest.
+
+Covers:
+  - _classify_error helper: maps SF error codes to "bisect" | "isolate" | None
+  - _sync_isolated_rows: per-Id fetch with skip-on-overflow
+  - _query_recur end-to-end: Numeric Overflow → bisect → isolate-mode → skip offender
+  - Regression: pure OPERATION_TOO_LARGE that bottoms out at <1h still raises
+
+Mocks Salesforce REST by patching `Rest.sf._make_request` to return canned
+Response-like objects based on the SOQL `q` parameter, so the test exercises
+the actual bisection + isolation logic without network access.
+
+Source: RGI tenant 5578 Task Call_Log_Link__c — 2026-05-28.
+"""
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from tap_salesforce.salesforce.rest import (
+    Rest,
+    MIN_BISECT_SECONDS,
+    _classify_error,
+)
+from tap_salesforce.salesforce.exceptions import TapSalesforceExceptionError
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _http_error(status_code, body):
+    """Build a requests.HTTPError carrying a JSON body, as Salesforce returns."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = body
+    return HTTPError(response=response)
+
+
+def _ok_response(records, next_records_url=None):
+    """Build a Response-like object with .json() returning a SF query payload."""
+    resp = MagicMock()
+    resp.json.return_value = {
+        "records": records,
+        "nextRecordsUrl": next_records_url,
+        "done": next_records_url is None,
+    }
+    return resp
+
+
+def _catalog_entry(stream="Contact", replication_key="SystemModstamp"):
+    """Minimal catalog_entry shape expected by _query_recur and _build_query_string."""
+    return {
+        "stream": stream,
+        "tap_stream_id": stream,
+        "metadata": [
+            {
+                "breadcrumb": [],
+                "metadata": {
+                    "replication-key": replication_key,
+                    "replication-method": "INCREMENTAL",
+                },
+            }
+        ],
+    }
+
+
+def _make_fake_sf(request_dispatcher, build_query_string=None):
+    """Construct a fake Salesforce instance suitable for Rest._query_recur.
+
+    `request_dispatcher` receives (method, url, headers, params) on each
+    `_make_request` call and returns either a Response-like object or raises
+    HTTPError. It lets tests script the sequence of SF responses.
+
+    `build_query_string` mimics the real one with enough fidelity for tests:
+    returns "SELECT * FROM <stream> WHERE <repl_key> >= <start> [AND <repl_key> < <end>] ORDER BY <repl_key> ASC".
+    """
+    def default_build_query_string(catalog_entry, start_date, end_date=None,
+                                   order_by_clause=True):
+        # Emit a multi-column projection so dispatchers can distinguish:
+        #   - bisect / normal query:     "SELECT Id,SystemModstamp FROM ..."
+        #   - isolate Id-enumeration:    "SELECT Id FROM ..."        (literal in _sync_isolated_rows)
+        #   - per-Id fetch (isolate):    "SELECT Id,SystemModstamp FROM ... AND Id = '...'"
+        repl = "SystemModstamp"
+        q = f"SELECT Id,{repl} FROM {catalog_entry['stream']} WHERE {repl} >= {start_date}"
+        if end_date:
+            q += f" AND {repl} < {end_date}"
+        if order_by_clause:
+            q += f" ORDER BY {repl} ASC"
+        return q
+
+    sf = MagicMock()
+    sf.instance_url = "https://test.my.salesforce.com"
+    sf.auth.rest_headers = {"Authorization": "Bearer fake"}
+    sf._make_request.side_effect = request_dispatcher
+    sf._build_query_string.side_effect = build_query_string or default_build_query_string
+    return sf
+
+
+# --------------------------------------------------------------------------- #
+# 1. _classify_error helper                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestClassifyError:
+    """Unit tests for the pure error-classification helper."""
+
+    @pytest.mark.parametrize("code", ["QUERY_TIMEOUT", "OPERATION_TOO_LARGE"])
+    def test_bisectable_codes_return_bisect(self, code):
+        print(f"\n--- test_bisectable_codes_return_bisect ({code}) ---")
+        body = [{"errorCode": code, "message": "x"}]
+        result = _classify_error(body)
+        print(f"  Input errorCode: {code} → classified as: {result}")
+        assert result == "bisect"
+
+    def test_numeric_overflow_returns_isolate(self):
+        print("\n--- test_numeric_overflow_returns_isolate ---")
+        body = [{"errorCode": "UNKNOWN_EXCEPTION", "message": "Numeric Overflow"}]
+        result = _classify_error(body)
+        print(f"  Input: UNKNOWN_EXCEPTION/'Numeric Overflow' → classified as: {result}")
+        assert result == "isolate"
+
+    def test_numeric_overflow_within_longer_message_returns_isolate(self):
+        """Salesforce sometimes wraps the message with extra context; substring match."""
+        print("\n--- test_numeric_overflow_within_longer_message_returns_isolate ---")
+        body = [{"errorCode": "UNKNOWN_EXCEPTION",
+                 "message": "An exception occurred: Numeric Overflow at row 5"}]
+        result = _classify_error(body)
+        assert result == "isolate"
+
+    def test_unknown_exception_without_numeric_overflow_returns_none(self):
+        """Don't broaden the skip path — only Numeric Overflow opts in."""
+        print("\n--- test_unknown_exception_without_numeric_overflow_returns_none ---")
+        body = [{"errorCode": "UNKNOWN_EXCEPTION", "message": "Something else broke"}]
+        result = _classify_error(body)
+        print(f"  Input: UNKNOWN_EXCEPTION/'Something else broke' → classified as: {result}")
+        assert result is None
+
+    @pytest.mark.parametrize("body", [
+        None,
+        [],
+        "not a list",
+        [{"errorCode": "INVALID_FIELD", "message": "No such column"}],
+    ])
+    def test_other_inputs_return_none(self, body):
+        print(f"\n--- test_other_inputs_return_none ({body!r}) ---")
+        assert _classify_error(body) is None
+
+
+# --------------------------------------------------------------------------- #
+# 2. _sync_isolated_rows direct                                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestSyncIsolatedRows:
+    """Unit tests for the per-Id isolation helper."""
+
+    def test_skips_offending_row_yields_others(self, caplog):
+        """Given 5 Ids where one returns Numeric Overflow on full-projection
+        fetch, _sync_isolated_rows yields the other 4 and logs an ERROR for
+        the skipped one."""
+        print("\n--- test_skips_offending_row_yields_others ---")
+
+        bad_id = "00TPV00001AZX842AH"
+        good_ids = ["00TPV00001AAA000001", "00TPV00001BBB000002",
+                    "00TPV00001CCC000003", "00TPV00001DDD000004"]
+        all_ids = [good_ids[0], good_ids[1], bad_id, good_ids[2], good_ids[3]]
+
+        # Track call sequence so we can assert behaviour after.
+        calls = []
+
+        def dispatcher(method, url, headers, params):
+            q = params["q"]
+            calls.append(q)
+            # Order matters: per-Id branches first (full-projection queries that
+            # happen to contain `Id = '…'`), then the literal "SELECT Id FROM"
+            # enumeration. The fake _build_query_string emits "SELECT Id,SystemModstamp …"
+            # for the full projection, while _sync_isolated_rows builds a literal
+            # "SELECT Id FROM …" for its enumeration step.
+            if f"Id = '{bad_id}'" in q:
+                raise _http_error(500, [{
+                    "errorCode": "UNKNOWN_EXCEPTION",
+                    "message": "Numeric Overflow",
+                }])
+            for gid in good_ids:
+                if f"Id = '{gid}'" in q:
+                    return _ok_response([{"Id": gid, "SystemModstamp": "2025-09-15T16:44:36.000+0000"}])
+            if q.startswith("SELECT Id FROM Contact"):
+                return _ok_response([{"Id": _id} for _id in all_ids])
+            raise AssertionError(f"Unexpected query: {q}")
+
+        rest = Rest(_make_fake_sf(dispatcher))
+
+        with caplog.at_level(logging.ERROR, logger=""):
+            yielded = list(rest._sync_isolated_rows(
+                _catalog_entry(stream="Contact"),
+                "2025-09-15T16:44:31Z",
+                "2025-09-15T16:44:36Z",
+            ))
+
+        print(f"  Rows yielded: {len(yielded)} (expected 4)")
+        print(f"  Yielded Ids:  {[r['Id'] for r in yielded]}")
+        assert len(yielded) == 4
+        assert {r["Id"] for r in yielded} == set(good_ids)
+
+        # ERROR log assertions
+        skip_logs = [r for r in caplog.records
+                     if "MDI_SFDC_NUMERIC_OVERFLOW_ROW_SKIPPED" in r.message]
+        print(f"  Skip log entries: {len(skip_logs)}")
+        assert len(skip_logs) == 1
+        assert bad_id in skip_logs[0].message
+        assert "stream=Contact" in skip_logs[0].message
+
+        # We expect 1 Id-list query + 5 per-Id queries = 6 total
+        print(f"  Total REST calls: {len(calls)} (expected 6 = 1 Id-list + 5 per-Id)")
+        assert len(calls) == 6
+
+    def test_empty_window_yields_nothing_and_does_not_error(self):
+        """If the Id list is empty (nothing in the window), we just return."""
+        print("\n--- test_empty_window_yields_nothing_and_does_not_error ---")
+
+        def dispatcher(method, url, headers, params):
+            if params["q"].startswith("SELECT Id FROM Contact"):
+                return _ok_response([])  # empty
+            raise AssertionError(f"Unexpected query: {params['q']}")
+
+        rest = Rest(_make_fake_sf(dispatcher))
+        yielded = list(rest._sync_isolated_rows(
+            _catalog_entry(),
+            "2025-09-15T16:44:31Z",
+            "2025-09-15T16:44:36Z",
+        ))
+        assert yielded == []
+
+    def test_non_overflow_http_error_propagates(self):
+        """If a per-Id fetch fails for a different reason, don't swallow it."""
+        print("\n--- test_non_overflow_http_error_propagates ---")
+
+        def dispatcher(method, url, headers, params):
+            q = params["q"]
+            # Per-Id full-projection fetch (contains `Id = '…'`): non-overflow error
+            if "Id = '00TX001'" in q:
+                raise _http_error(401, [{
+                    "errorCode": "INVALID_SESSION_ID",
+                    "message": "Session expired or invalid",
+                }])
+            # Bare "SELECT Id FROM …" enumeration: return our one Id
+            if q.startswith("SELECT Id FROM Contact"):
+                return _ok_response([{"Id": "00TX001"}])
+            raise AssertionError(f"Unexpected query: {q}")
+
+        rest = Rest(_make_fake_sf(dispatcher))
+        with pytest.raises(HTTPError):
+            list(rest._sync_isolated_rows(
+                _catalog_entry(),
+                "2025-09-15T16:44:31Z",
+                "2025-09-15T16:44:36Z",
+            ))
+
+
+# --------------------------------------------------------------------------- #
+# 3. _query_recur end-to-end: bisect → isolate                                 #
+# --------------------------------------------------------------------------- #
+
+
+class TestQueryRecurIsolatePath:
+    """Integration: full _query_recur flow exercising the Numeric Overflow path."""
+
+    def test_numeric_overflow_at_full_window_falls_through_to_isolate(self, caplog):
+        """A small-enough full window with Numeric Overflow goes:
+           top-level call → bisect (still overflows on left half, succeeds on right)
+           → left half bisects below MIN_BISECT_SECONDS → isolate mode kicks in
+           → bad Id skipped, others yielded.
+
+        We pick a 2-hour total window so a single bisect lands at 1 h
+        (== MIN_BISECT_SECONDS — actually below the strict `<` guard) and
+        switches into isolate-mode immediately on the bottom half.
+        """
+        print("\n--- test_numeric_overflow_at_full_window_falls_through_to_isolate ---")
+
+        bad_id = "00TPV00001AZX842AH"
+        good_id = "00TPV00001AAA000001"
+
+        # 2-hour window: 2025-09-15T16:00 → 18:00. half_range = 1h, which is
+        # NOT < MIN_BISECT_SECONDS (3600s) on the first bisect — so we need a
+        # smaller window. Pick 1h59m so half = 59m30s = 3570s < 3600s.
+        start_str = "2025-09-15T16:00:00.000Z"
+        end_str = "2025-09-15T17:59:00.000Z"
+
+        # Use an end_date in the past so _query_recur's "chunk to now" branch
+        # is short-circuited (end_date < sync_start is True but the recursive
+        # call uses end_date as new start, which is fine for this test as we
+        # script the dispatcher to return empty for it).
+        import datetime as _dt
+        end_date = _dt.datetime(2025, 9, 15, 17, 59, 0, tzinfo=_dt.timezone.utc)
+
+        def dispatcher(method, url, headers, params):
+            q = params["q"]
+            print(f"  dispatcher: {q[:140]}")
+            # Branch order matters — see comment in TestSyncIsolatedRows.
+            # 1. Per-Id full-projection fetches (isolate mode): match the bad
+            #    Id first so it raises Numeric Overflow; good Ids return cleanly.
+            if f"Id = '{bad_id}'" in q:
+                raise _http_error(500, [{
+                    "errorCode": "UNKNOWN_EXCEPTION",
+                    "message": "Numeric Overflow",
+                }])
+            if f"Id = '{good_id}'" in q:
+                return _ok_response([{"Id": good_id,
+                                      "SystemModstamp": "2025-09-15T16:30:00.000+0000"}])
+            # 2. The literal "SELECT Id FROM …" enumeration that _sync_isolated_rows
+            #    builds (only Id in projection, both date bounds).
+            if q.startswith("SELECT Id FROM Contact") and " AND SystemModstamp <" in q:
+                return _ok_response([{"Id": good_id}, {"Id": bad_id}])
+            # 3. Any full-projection windowed query (fake builder emits
+            #    "SELECT Id,SystemModstamp FROM …"): raise Numeric Overflow to
+            #    drive the bisection chain.
+            if q.startswith("SELECT Id,SystemModstamp FROM Contact") and " AND SystemModstamp <" in q:
+                raise _http_error(500, [{
+                    "errorCode": "UNKNOWN_EXCEPTION",
+                    "message": "Numeric Overflow",
+                }])
+            # 4. The post-chunk "from end_date → now" sub-recursion (no upper
+            #    bound). Return empty so we don't drift into unrelated paths.
+            return _ok_response([])
+
+        rest = Rest(_make_fake_sf(dispatcher))
+
+        # Build the initial query the same way the real query() entry-point
+        # would, so the first REST call matches the bisect-trigger pattern in
+        # rule #3 of the dispatcher.
+        catalog = _catalog_entry(stream="Contact")
+        initial_query = rest.sf._build_query_string(
+            catalog, start_str, end_str_iso := "2025-09-15T17:59:00.000Z",
+        )
+        assert "AND SystemModstamp <" in initial_query, (
+            f"Initial query must trigger dispatcher rule #3 for the test to be "
+            f"meaningful; got: {initial_query}"
+        )
+
+        with caplog.at_level(logging.INFO, logger=""):
+            yielded = list(rest._query_recur(
+                query=initial_query,
+                catalog_entry=catalog,
+                start_date_str=start_str,
+                end_date=end_date,
+                retries=8,
+            ))
+
+        ids = [r["Id"] for r in yielded if "Id" in r]
+        print(f"  Yielded Ids (deduped): {sorted(set(ids))}")
+        assert good_id in ids, "Good record should be yielded via isolate mode"
+        assert bad_id not in ids, "Bad record must be skipped"
+
+        # Confirm isolate-mode log fired
+        skip_logs = [r for r in caplog.records
+                     if "MDI_SFDC_NUMERIC_OVERFLOW_ROW_SKIPPED" in r.message]
+        assert len(skip_logs) >= 1
+        assert bad_id in skip_logs[0].message
+
+    def test_pure_operation_too_large_below_1h_still_raises(self):
+        """Regression: pure OPERATION_TOO_LARGE that bisects below 1h must
+        still raise the existing TapSalesforceExceptionError — we did not
+        change that branch."""
+        print("\n--- test_pure_operation_too_large_below_1h_still_raises ---")
+
+        import datetime as _dt
+        start_str = "2025-09-15T16:00:00.000Z"
+        end_date = _dt.datetime(2025, 9, 15, 17, 59, 0, tzinfo=_dt.timezone.utc)
+
+        def dispatcher(method, url, headers, params):
+            # Every query fails with OPERATION_TOO_LARGE so bisection bottoms out.
+            raise _http_error(400, [{
+                "errorCode": "OPERATION_TOO_LARGE",
+                "message": "Too many records",
+            }])
+
+        rest = Rest(_make_fake_sf(dispatcher))
+        with pytest.raises(TapSalesforceExceptionError, match="less than 1 hour"):
+            list(rest._query_recur(
+                query="initial",
+                catalog_entry=_catalog_entry(stream="Contact"),
+                start_date_str=start_str,
+                end_date=end_date,
+                retries=8,
+            ))
+
+
+# --------------------------------------------------------------------------- #
+# 4. Module-level constants sanity                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_min_bisect_seconds_is_one_hour():
+    """If this changes, the cost/coverage tradeoff for isolate-mode shifts —
+    surface it as a deliberate test failure rather than a silent edit."""
+    assert MIN_BISECT_SECONDS == 3600


### PR DESCRIPTION
Skip rows that hit UNKNOWN_EXCEPTION:Numeric Overflow during sync

Salesforce returns 500 Numeric Overflow when a row's formula field overflows during REST serialisation; the error is row-scoped and cannot be recovered by date-range bisection. Added a _classify_error helper, an isolate_mode flag carried through _query_recur's recursion, and a new _sync_isolated_rows helper that, when bisection reaches MIN_BISECT_SECONDS=3600, enumerates Ids in the window and re-fetches each with the full projection — logging+skipping any that still overflow. Existing OPERATION_TOO_LARGE / QUERY_TIMEOUT paths unchanged.
Source: RGI tenant 5578 Task Id 00TPV00001AZX842AH, Call_Log_Link__c. Tests in tests/test_numeric_overflow_skip.py