### PR TITLE
feat(rtr): RTR-safe credential management via Argo + bongo delegation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pytest pytest-mock requests simple_salesforce
+      - name: Run tests
+        run: pytest tests/test_credentials.py -v

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 from datetime import timedelta
 
@@ -353,6 +354,33 @@ class Salesforce:
     def instance_url(self):
         return self.auth.instance_url
 
+    def _is_session_expired(self, resp) -> bool:
+        """Return True if the 401 indicates a session expiry.
+
+        Returns True when the response body contains INVALID_SESSION_ID, or
+        when the body cannot be parsed (treated conservatively as expired).
+        """
+        try:
+            body = resp.json()
+            return any(
+                err.get("errorCode") == "INVALID_SESSION_ID"
+                for err in (body if isinstance(body, list) else [])
+            )
+        except Exception:
+            return True  # treat unparseable 401 as expired session
+
+    def _rebuild_headers_with_new_at(self, headers) -> dict:
+        """Return a new headers dict with the current access token injected.
+
+        Callers use either Authorization (REST) or X-SFDC-Session (Bulk).
+        """
+        new_at = self.auth._access_token
+        if "Authorization" in headers:
+            return {**headers, "Authorization": f"Bearer {new_at}"}
+        if "X-SFDC-Session" in headers:
+            return {**headers, "X-SFDC-Session": new_at}
+        return headers
+
     # pylint: disable=too-many-arguments
     @backoff.on_exception(
         backoff.expo,
@@ -366,15 +394,55 @@ class Salesforce:
         # Kept as close to the wire call as possible so the timer measures actual
         # network + SFDC latency, not any bookkeeping.
         request_start = singer_utils.now()
+        LOGGER.info("Making %s request to %s with params: %s", http_method, url, params or body)
         if http_method == "GET":
-            LOGGER.info("Making %s request to %s with params: %s", http_method, url, params)
             resp = self.session.get(url, headers=headers, stream=stream, params=params)
         elif http_method == "POST":
-            LOGGER.info("Making %s request to %s with body %s", http_method, url, body)
             resp = self.session.post(url, headers=headers, data=body)
         else:
             raise TapSalesforceExceptionError("Unsupported HTTP method")
         duration_ms = (singer_utils.now() - request_start).total_seconds() * 1000.0
+
+        # 401 = expired AT. Refresh via bongo and retry once.
+        if resp.status_code == 401:
+            tenant = os.environ.get("TENANT", "unknown")
+            if self._is_session_expired(resp) and hasattr(self.auth, "refresh_access_token"):
+                LOGGER.warning(
+                    "SF data query: 401 INVALID_SESSION_ID — AT expired, refreshing "
+                    "event=sf_401_detected tenant=%s url=%s",
+                    tenant, url,
+                )
+                try:
+                    self.auth.refresh_access_token()
+                    LOGGER.info(
+                        "SF data query: AT refreshed, retrying request "
+                        "event=sf_at_refresh_done tenant=%s url=%s",
+                        tenant, url,
+                    )
+                    headers = self._rebuild_headers_with_new_at(headers)
+                    if http_method == "GET":
+                        resp = self.session.get(url, headers=headers, stream=stream, params=params)
+                    else:
+                        resp = self.session.post(url, headers=headers, data=body)
+                    if resp.status_code == 401:
+                        LOGGER.error(
+                            "SF data query: retry also returned 401 — propagating error "
+                            "event=sf_retry_401 tenant=%s url=%s",
+                            tenant, url,
+                        )
+                except Exception as refresh_err:
+                    LOGGER.error(
+                        "SF data query: AT refresh failed — request will fail "
+                        "event=sf_at_refresh_failed tenant=%s url=%s error=%s",
+                        tenant, url, refresh_err,
+                    )
+                    raise
+            else:
+                LOGGER.warning(
+                    "SF data query: 401 but not INVALID_SESSION_ID — not retrying "
+                    "event=sf_401_not_session tenant=%s url=%s body=%s",
+                    tenant, url, resp.text[:200],
+                )
 
         raise_for_status(resp)
 

--- a/tap_salesforce/salesforce/credentials.py
+++ b/tap_salesforce/salesforce/credentials.py
@@ -1,4 +1,6 @@
+import base64
 import logging
+import os
 import threading
 from collections import namedtuple
 
@@ -13,7 +15,28 @@ OAuthCredentials = namedtuple("OAuthCredentials", ("client_id", "client_secret",
 PasswordCredentials = namedtuple("PasswordCredentials", ("username", "password", "security_token"))
 
 
+_ARGO_MODE_REQUIRED = (
+    "ARGO_URL",
+    "TENANT",
+    "ARGO_CONNECTOR_API_KEY",
+    "BONGO_API_TARGET_URL",
+    "BONGO_API_BASIC_AUTH_USERNAME",
+)
+
+
 def parse_credentials(config):
+    # Argo mode: all credentials come from Argo/bongo at runtime.
+    # Fail fast if any required env var is absent — do not start the sync
+    # with missing auth config. Password-auth tenants must NOT set ARGO_URL.
+    if os.environ.get("ARGO_URL"):
+        missing = [k for k in _ARGO_MODE_REQUIRED if not os.environ.get(k)]
+        if missing:
+            raise RuntimeError(
+                f"SF RTR: missing required env vars for Argo mode: {', '.join(missing)}. "
+                "Set them in the ECS task definition."
+            )
+        return OAuthCredentials(client_id="", client_secret="", refresh_token="")
+
     for cls in reversed((OAuthCredentials, PasswordCredentials)):
         creds = cls(*(config.get(key) for key in cls._fields))
         if all(creds):
@@ -53,10 +76,8 @@ class SalesforceAuth:
     def from_credentials(cls, credentials, **kwargs):
         if isinstance(credentials, OAuthCredentials):
             return SalesforceAuthOAuth(credentials, **kwargs)
-
         if isinstance(credentials, PasswordCredentials):
             return SalesforceAuthPassword(credentials, **kwargs)
-
         raise Exception("Invalid credentials")
 
 
@@ -64,55 +85,166 @@ class SalesforceAuthOAuth(SalesforceAuth):
     # The minimum expiration setting for SF Refresh Tokens is 15 minutes
     REFRESH_TOKEN_EXPIRATION_PERIOD = 900
 
-    @property
-    def _login_body(self):
-        return {"grant_type": "refresh_token", **self._credentials._asdict()}
-
-    @property
-    def _login_url(self):
-        # Simulator override env var for login URL
-        import os
-        override = os.environ.get("SIMULATOR_TAP_SALESFORCE_LOGIN_URL")
-        if override:
-            return override
-
-        login_url = "https://login.salesforce.com/services/oauth2/token"
-
-        if self.is_sandbox:
-            login_url = "https://test.salesforce.com/services/oauth2/token"
-
-        return login_url
-
     def login(self):
-        try:
-            LOGGER.info("Attempting login via OAuth2")
-
-            resp = requests.post(
-                self._login_url,
-                data=self._login_body,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
+        # parse_credentials() already validated all required env vars at startup.
+        # If we reach here without them, something bypassed the normal entry point.
+        argo_url = os.environ.get("ARGO_URL", "")
+        tenant = os.environ.get("TENANT", "")
+        if not argo_url or not tenant:
+            raise RuntimeError(
+                "ARGO_URL and TENANT are required. "
+                "Ensure parse_credentials() was called with ARGO_URL set."
             )
+        self._sync_from_argo(argo_url, tenant)
 
-            resp.raise_for_status()
-            auth = resp.json()
+    # ── Timer path: read-only Argo sync ────────────────────────────────────────
 
-            LOGGER.info("OAuth2 login successful")
-            self._access_token = auth["access_token"]
-            self._instance_url = auth["instance_url"]
+    def _sync_from_argo(self, argo_url: str, tenant: str) -> None:
+        """Read access_token and instance_url from Argo. No SF call, no lock.
+
+        Called at startup and every 15 min by the timer. Picks up any fresh AT
+        that node services (mk-push, mk-pull, mk-bongo) may have rotated into
+        Argo since the last sync. If the AT is expired, the next SF data query
+        will return 401 which triggers refresh_access_token().
+        """
+        try:
+            creds = self._fetch_argo_credentials(argo_url, tenant)
+            at_updated = self._update_credentials(creds)
+            if not self._access_token:
+                LOGGER.warning(
+                    "SF RTR: Argo returned no access_token — next SF query will fail "
+                    "event=argo_no_at tenant=%s",
+                    tenant,
+                )
+            else:
+                LOGGER.info(
+                    "SF RTR: credentials synced from Argo event=credentials_synced "
+                    "tenant=%s at_updated=%s",
+                    tenant, at_updated,
+                )
         except Exception as e:
-            error_message = str(e)
-            if resp:
-                error_message = error_message + f", Response from Salesforce: {resp.text}"
-            raise Exception(error_message) from e
+            LOGGER.error(
+                "SF RTR: failed to sync credentials from Argo event=argo_sync_failed "
+                "tenant=%s error=%s", tenant, e,
+            )
+            raise
         finally:
-            LOGGER.info("Starting new login timer")
             self.login_timer = threading.Timer(self.REFRESH_TOKEN_EXPIRATION_PERIOD, self.login)
             self.login_timer.start()
+
+    # ── 401 path: delegate refresh to bongo ────────────────────────────────────
+
+    def refresh_access_token(self) -> None:
+        """Refresh the AT by delegating to bongo's SF ping endpoint.
+
+        Bongo owns the full RTR-safe lock protocol (lockAwareRefreshFn in
+        mk-node-libs). The tap never calls SF OAuth directly — it just triggers
+        bongo to refresh and then reads the result from Argo.
+        """
+        argo_url, bongo_url, tenant, bongo_auth = self._argo_config()
+        LOGGER.info(
+            "SF RTR: AT expired — delegating refresh to bongo "
+            "event=at_refresh_triggered tenant=%s",
+            tenant,
+        )
+        try:
+            self._ping_bongo(bongo_url, bongo_auth, tenant)
+            LOGGER.info(
+                "SF RTR: reading fresh AT from Argo event=argo_read_after_ping tenant=%s", tenant,
+            )
+            creds = self._fetch_argo_credentials(argo_url, tenant)
+            self._apply_fresh_at(creds, tenant)
+        except Exception as e:
+            LOGGER.error(
+                "SF RTR: AT refresh via bongo failed event=at_refresh_error "
+                "tenant=%s error=%s", tenant, e,
+            )
+            raise
+
+    # ── Private helpers ─────────────────────────────────────────────────────────
+
+    def _argo_config(self):
+        """Read and validate Argo/bongo env vars; return (argo_url, bongo_url, tenant, bongo_auth)."""
+        argo_url = os.environ.get("ARGO_URL", "")
+        bongo_url = os.environ.get("BONGO_API_TARGET_URL", "")
+        tenant = os.environ.get("TENANT", "")
+        if not argo_url or not bongo_url or not tenant:
+            raise RuntimeError(
+                "ARGO_URL, BONGO_API_TARGET_URL, and TENANT are required. "
+                "Ensure parse_credentials() was called with ARGO_URL set."
+            )
+        bongo_username = os.environ.get("BONGO_API_BASIC_AUTH_USERNAME", "")
+        if not bongo_username:
+            LOGGER.warning(
+                "SF RTR: BONGO_API_BASIC_AUTH_USERNAME not set — bongo requests unauthenticated "
+                "tenant=%s", tenant,
+            )
+        return argo_url, bongo_url, tenant, self._basic_auth(bongo_username)
+
+    def _ping_bongo(self, bongo_url: str, bongo_auth: str, tenant: str) -> None:
+        """Call bongo's SF ping endpoint. Bongo triggers lockAwareRefreshFn if AT is expired."""
+        LOGGER.info("SF RTR: calling bongo ping event=bongo_ping_started tenant=%s", tenant)
+        resp = requests.get(
+            f"{bongo_url}/v1/org/{tenant}/integrations/salesforce/ping",
+            headers={"Authorization": bongo_auth},
+            timeout=60,  # bongo may need to wait for the Argo lock + call SF
+        )
+        resp.raise_for_status()
+        tested = resp.json().get("tested", False)
+        if tested:
+            LOGGER.info("SF RTR: bongo ping succeeded event=bongo_ping_success tenant=%s", tenant)
+        else:
+            # tested=false is unlikely for Salesforce (broken connections raise exceptions).
+            LOGGER.warning(
+                "SF RTR: bongo ping returned tested=false event=bongo_ping_failed "
+                "tenant=%s — SF connector may need reconnection", tenant,
+            )
+
+    def _update_credentials(self, creds: dict) -> bool:
+        """Apply access_token and instance_url from Argo creds. Returns True if AT changed."""
+        prev = self._access_token
+        if creds.get("access_token"):
+            self._access_token = creds["access_token"]
+        if creds.get("instance_url"):
+            self._instance_url = creds["instance_url"]
+        return prev is not None and self._access_token != prev
+
+    def _apply_fresh_at(self, creds: dict, tenant: str) -> None:
+        """Update AT from Argo creds after a bongo ping; log whether it changed."""
+        changed = self._update_credentials(creds)
+        if changed:
+            LOGGER.info(
+                "SF RTR: AT refreshed successfully event=at_refresh_success tenant=%s", tenant,
+            )
+        else:
+            # AT unchanged — bongo may have adopted an existing valid AT,
+            # or the connected app does not rotate tokens. The retry may still 401.
+            LOGGER.warning(
+                "SF RTR: AT unchanged after bongo ping event=at_unchanged_after_ping "
+                "tenant=%s — retry may still return 401", tenant,
+            )
+
+    @staticmethod
+    def _basic_auth(key: str) -> str:
+        """Basic auth header value: Basic base64(key + ':')."""
+        return "Basic " + base64.b64encode(f"{key}:".encode()).decode()
+
+    def _argo_auth(self) -> str:
+        return self._basic_auth(os.environ.get("ARGO_CONNECTOR_API_KEY", ""))
+
+    def _fetch_argo_credentials(self, argo_url: str, tenant: str) -> dict:
+        """GET current connector credentials from Argo."""
+        resp = requests.get(
+            f"{argo_url}/v1/tenant/{tenant}/connectors/salesforce",
+            headers={"Authorization": self._argo_auth()},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json().get("credentials") or {}
 
 
 class SalesforceAuthPassword(SalesforceAuth):
     def login(self):
         login = SalesforceLogin(sandbox=self.is_sandbox, **self._credentials._asdict())
-
         self._access_token, host = login
         self._instance_url = "https://" + host

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,341 @@
+# ruff: noqa: SLF001
+"""Unit tests for Argo/bongo-backed credential management in SalesforceAuthOAuth."""
+
+import base64
+import importlib.util
+import os
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "credentials",
+    Path(__file__).parent.parent / "tap_salesforce" / "salesforce" / "credentials.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+OAuthCredentials = _mod.OAuthCredentials
+SalesforceAuthOAuth = _mod.SalesforceAuthOAuth
+parse_credentials = _mod.parse_credentials
+
+
+CREDS = OAuthCredentials(client_id="", client_secret="", refresh_token="")
+ARGO_ENV = {"ARGO_URL": "http://argo", "TENANT": "42", "ARGO_CONNECTOR_API_KEY": "argo-key"}
+BONGO_ENV = {**ARGO_ENV, "BONGO_API_TARGET_URL": "http://bongo", "BONGO_API_BASIC_AUTH_USERNAME": "F4BFB409-TEST"}
+
+_ARGO_AUTH  = "Basic " + base64.b64encode(b"argo-key:").decode()
+_BONGO_AUTH = "Basic " + base64.b64encode(b"F4BFB409-TEST:").decode()
+
+
+def _make_auth():
+    return SalesforceAuthOAuth(CREDS)
+
+
+def _mock_resp(json_data, status=200):
+    r = MagicMock()
+    r.json.return_value = json_data
+    r.raise_for_status = MagicMock()
+    if status >= 400:
+        r.raise_for_status.side_effect = Exception(f"HTTP {status}")
+    return r
+
+
+def _argo_creds(at="AT1"):
+    return _mock_resp({"credentials": {"access_token": at, "instance_url": "https://sf"}})
+
+
+# ── parse_credentials ──────────────────────────────────────────────────────────
+
+_ALL_REQUIRED = {
+    "ARGO_URL": "http://argo",
+    "TENANT": "42",
+    "ARGO_CONNECTOR_API_KEY": "argo-key",
+    "BONGO_API_TARGET_URL": "http://bongo",
+    "BONGO_API_BASIC_AUTH_USERNAME": "bongo-user",
+}
+
+
+class TestParseCredentials:
+    def test_argo_mode_returns_empty_oauth_credentials(self):
+        """All 5 vars set → returns empty OAuthCredentials for Argo bootstrap."""
+        with patch.dict("os.environ", _ALL_REQUIRED):
+            creds = parse_credentials({})
+        assert isinstance(creds, OAuthCredentials)
+        assert creds.client_id == "" and creds.client_secret == "" and creds.refresh_token == ""
+
+    def test_argo_mode_ignores_config_fields(self):
+        """Config fields are irrelevant in Argo mode — credentials come from Argo at runtime."""
+        with patch.dict("os.environ", _ALL_REQUIRED):
+            creds = parse_credentials({"client_id": "ignored", "refresh_token": "ignored"})
+        assert creds.client_id == "" and creds.refresh_token == ""
+
+    @pytest.mark.parametrize("missing", [
+        "TENANT", "ARGO_CONNECTOR_API_KEY", "BONGO_API_TARGET_URL", "BONGO_API_BASIC_AUTH_USERNAME",
+    ])
+    def test_fails_immediately_when_any_required_var_missing(self, missing):
+        """When ARGO_URL is set (Argo mode), all other vars must be present — fail fast."""
+        env = {k: v for k, v in _ALL_REQUIRED.items() if k != missing}
+        with patch.dict("os.environ", env, clear=False):
+            os.environ.pop(missing, None)
+            with pytest.raises(RuntimeError, match="missing required env vars"):
+                parse_credentials({})
+
+    def test_error_message_names_missing_vars(self):
+        """Error message lists which specific vars are missing."""
+        env = {"ARGO_URL": "http://argo"}  # missing 4 vars
+        with patch.dict("os.environ", env, clear=False):
+            for k in _ALL_REQUIRED:
+                if k != "ARGO_URL":
+                    os.environ.pop(k, None)
+            with pytest.raises(RuntimeError) as exc_info:
+                parse_credentials({})
+        msg = str(exc_info.value)
+        assert "TENANT" in msg
+        assert "BONGO_API_TARGET_URL" in msg
+
+    @pytest.mark.parametrize("empty_var", [
+        "TENANT", "ARGO_CONNECTOR_API_KEY", "BONGO_API_TARGET_URL", "BONGO_API_BASIC_AUTH_USERNAME",
+    ])
+    def test_empty_string_var_treated_as_missing(self, empty_var):
+        """Empty string is falsy — treated same as absent. ECS task with blank Variable fails fast."""
+        env = {**_ALL_REQUIRED, empty_var: ""}
+        with patch.dict("os.environ", env, clear=False):
+            with pytest.raises(RuntimeError, match="missing required env vars"):
+                parse_credentials({})
+
+
+# ── login() ────────────────────────────────────────────────────────────────────
+
+class TestLogin:
+    def test_raises_when_argo_url_missing_at_login(self):
+        """Defense-in-depth: login() raises if ARGO_URL is absent even after parse_credentials."""
+        auth = _make_auth()
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("ARGO_URL", None)
+            with pytest.raises(RuntimeError):
+                auth.login()
+
+
+# ── _sync_from_argo() — timer path ────────────────────────────────────────────
+
+class TestSyncFromArgo:
+    def test_sets_access_token_and_instance_url(self):
+        auth = _make_auth()
+        with patch.dict("os.environ", ARGO_ENV), \
+             patch("requests.get", return_value=_argo_creds("AT_LIVE")), \
+             patch.object(threading.Timer, "start"):
+            auth._sync_from_argo("http://argo", "42")
+        assert auth._access_token == "AT_LIVE"
+        assert auth._instance_url == "https://sf"
+
+    def test_timer_restarts_on_success(self):
+        mock_timer = MagicMock()
+        auth = _make_auth()
+        with patch.dict("os.environ", ARGO_ENV), \
+             patch("requests.get", return_value=_argo_creds()), \
+             patch("threading.Timer", return_value=mock_timer):
+            auth._sync_from_argo("http://argo", "42")
+        mock_timer.start.assert_called_once()
+
+    def test_timer_restarts_on_failure(self):
+        mock_timer = MagicMock()
+        auth = _make_auth()
+        with patch.dict("os.environ", ARGO_ENV), \
+             patch("requests.get", side_effect=Exception("Argo down")), \
+             patch("threading.Timer", return_value=mock_timer), \
+             pytest.raises(Exception):
+            auth._sync_from_argo("http://argo", "42")
+        mock_timer.start.assert_called_once()
+
+    def test_keeps_existing_at_when_argo_returns_empty(self):
+        auth = _make_auth()
+        auth._access_token = "EXISTING_AT"
+        with patch.dict("os.environ", ARGO_ENV), \
+             patch("requests.get", return_value=_mock_resp({"credentials": {}})), \
+             patch.object(threading.Timer, "start"):
+            auth._sync_from_argo("http://argo", "42")
+        assert auth._access_token == "EXISTING_AT"
+
+    def test_subsequent_calls_pick_up_updated_at(self):
+        auth = _make_auth()
+        with patch.dict("os.environ", ARGO_ENV), \
+             patch("requests.get") as mock_get, \
+             patch.object(threading.Timer, "start"):
+            mock_get.return_value = _argo_creds("AT1")
+            auth._sync_from_argo("http://argo", "42")
+            assert auth._access_token == "AT1"
+
+            mock_get.return_value = _argo_creds("AT2")
+            auth._sync_from_argo("http://argo", "42")
+            assert auth._access_token == "AT2"
+
+    def test_argo_failure_raises_and_logs(self, caplog):
+        auth = _make_auth()
+        with patch.dict("os.environ", ARGO_ENV), \
+             patch("requests.get", side_effect=Exception("timeout")), \
+             patch.object(threading.Timer, "start"), \
+             caplog.at_level("ERROR"), \
+             pytest.raises(Exception, match="timeout"):
+            auth._sync_from_argo("http://argo", "42")
+        assert any("argo_sync_failed" in r.message for r in caplog.records)
+
+    def test_empty_argo_credentials_logs_warning(self, caplog):
+        """Argo returns empty credentials at startup — AT stays None, warning logged."""
+        auth = _make_auth()
+        with patch.dict("os.environ", ARGO_ENV), \
+             patch("requests.get", return_value=_mock_resp({"credentials": {}})), \
+             patch.object(threading.Timer, "start"), \
+             caplog.at_level("WARNING"):
+            auth._sync_from_argo("http://argo", "42")
+        assert auth._access_token is None
+        assert any("argo_no_at" in r.message for r in caplog.records)
+
+    def test_update_credentials_returns_true_when_at_changes(self):
+        """_update_credentials returns True iff AT changed from a previous non-None value."""
+        auth = _make_auth()
+        auth._access_token = "OLD"
+        changed = auth._update_credentials({"access_token": "NEW", "instance_url": "https://sf"})
+        assert changed is True
+        assert auth._access_token == "NEW"
+
+    def test_update_credentials_returns_false_on_first_call(self):
+        """_update_credentials returns False on first call (prev AT was None)."""
+        auth = _make_auth()
+        changed = auth._update_credentials({"access_token": "AT1"})
+        assert changed is False  # prev was None → not "changed"
+        assert auth._access_token == "AT1"
+
+    def test_update_credentials_skips_empty_at(self):
+        """Empty access_token in creds is ignored — existing AT preserved."""
+        auth = _make_auth()
+        auth._access_token = "KEEP"
+        auth._update_credentials({"access_token": ""})
+        assert auth._access_token == "KEEP"
+
+
+# ── refresh_access_token() — 401 path ─────────────────────────────────────────
+
+class TestRefreshAccessToken:
+    def test_happy_path_pings_bongo_then_reads_from_argo(self):
+        """Bongo ping succeeds, fresh AT read from Argo."""
+        auth = _make_auth()
+        auth._access_token = "EXPIRED_AT"
+
+        with patch.dict("os.environ", BONGO_ENV), \
+             patch("requests.get") as mock_get, \
+             patch.object(threading.Timer, "start"):
+            mock_get.side_effect = [_mock_resp({"tested": True}), _argo_creds("FRESH_AT")]
+            auth.refresh_access_token()
+
+        assert auth._access_token == "FRESH_AT"
+        assert mock_get.call_count == 2
+        assert "bongo" in mock_get.call_args_list[0][0][0] and "ping" in mock_get.call_args_list[0][0][0]
+        assert "argo" in mock_get.call_args_list[1][0][0]
+
+    def test_both_requests_use_correct_basic_auth(self):
+        """Bongo uses Basic auth with BONGO username; Argo uses Basic auth with ARGO key."""
+        auth = _make_auth()
+        with patch.dict("os.environ", BONGO_ENV), \
+             patch("requests.get") as mock_get, \
+             patch.object(threading.Timer, "start"):
+            mock_get.side_effect = [_mock_resp({"tested": True}), _argo_creds("AT2")]
+            auth.refresh_access_token()
+
+        ping_auth = mock_get.call_args_list[0][1]["headers"]["Authorization"]
+        argo_auth = mock_get.call_args_list[1][1]["headers"]["Authorization"]
+        assert ping_auth == _BONGO_AUTH, f"Expected {_BONGO_AUTH}, got {ping_auth}"
+        assert argo_auth == _ARGO_AUTH,  f"Expected {_ARGO_AUTH}, got {argo_auth}"
+
+    def test_ping_tested_false_logs_warning_but_still_reads_argo(self, caplog):
+        """tested=false is an unlikely bongo non-failure — warn but still read from Argo."""
+        auth = _make_auth()
+        auth._access_token = "OLD_AT"
+        with patch.dict("os.environ", BONGO_ENV), \
+             patch("requests.get") as mock_get, \
+             patch.object(threading.Timer, "start"), \
+             caplog.at_level("WARNING"):
+            mock_get.side_effect = [_mock_resp({"tested": False}), _argo_creds("NEW_AT")]
+            auth.refresh_access_token()
+        assert any("bongo_ping_failed" in r.message for r in caplog.records)
+        assert auth._access_token == "NEW_AT"
+
+    def test_at_unchanged_after_ping_logs_warning(self, caplog):
+        auth = _make_auth()
+        auth._access_token = "SAME_AT"
+        with patch.dict("os.environ", BONGO_ENV), \
+             patch("requests.get") as mock_get, \
+             patch.object(threading.Timer, "start"), \
+             caplog.at_level("WARNING"):
+            mock_get.side_effect = [_mock_resp({"tested": True}), _argo_creds("SAME_AT")]
+            auth.refresh_access_token()
+        assert any("at_unchanged_after_ping" in r.message for r in caplog.records)
+
+    def test_bongo_error_raises_and_logs(self, caplog):
+        auth = _make_auth()
+        with patch.dict("os.environ", BONGO_ENV), \
+             patch("requests.get", side_effect=Exception("bongo unreachable")), \
+             patch.object(threading.Timer, "start"), \
+             caplog.at_level("ERROR"), \
+             pytest.raises(Exception, match="bongo unreachable"):
+            auth.refresh_access_token()
+        assert any("at_refresh_error" in r.message for r in caplog.records)
+
+    def test_raises_without_bongo_url(self):
+        auth = _make_auth()
+        with patch.dict("os.environ", ARGO_ENV):
+            with pytest.raises(RuntimeError, match="BONGO_API_TARGET_URL"):
+                auth.refresh_access_token()
+
+    def test_missing_bongo_auth_username_logs_warning(self, caplog):
+        auth = _make_auth()
+        env = {**BONGO_ENV, "BONGO_API_BASIC_AUTH_USERNAME": ""}
+        with patch.dict("os.environ", env), \
+             patch("requests.get") as mock_get, \
+             patch.object(threading.Timer, "start"), \
+             caplog.at_level("WARNING"):
+            mock_get.side_effect = [_mock_resp({"tested": True}), _argo_creds("AT2")]
+            auth.refresh_access_token()
+        assert any("BONGO_API_BASIC_AUTH_USERNAME not set" in r.message for r in caplog.records)
+
+    def test_bongo_non_json_response_raises_and_logs(self, caplog):
+        """Bongo returns HTTP 200 with non-JSON body (proxy HTML) → at_refresh_error."""
+        auth = _make_auth()
+        bad_resp = MagicMock()
+        bad_resp.raise_for_status = MagicMock()
+        bad_resp.json.side_effect = Exception("not json")
+        with patch.dict("os.environ", BONGO_ENV), \
+             patch("requests.get", return_value=bad_resp), \
+             patch.object(threading.Timer, "start"), \
+             caplog.at_level("ERROR"), \
+             pytest.raises(Exception, match="not json"):
+            auth.refresh_access_token()
+        assert any("at_refresh_error" in r.message for r in caplog.records)
+
+    def test_argo_returns_no_at_after_bongo_ping_logs_warning(self, caplog):
+        """Bongo ping succeeds but Argo returns no AT — at_unchanged_after_ping warning."""
+        auth = _make_auth()
+        auth._access_token = "CURRENT"
+        with patch.dict("os.environ", BONGO_ENV), \
+             patch("requests.get") as mock_get, \
+             patch.object(threading.Timer, "start"), \
+             caplog.at_level("WARNING"):
+            mock_get.side_effect = [
+                _mock_resp({"tested": True}),
+                _mock_resp({"credentials": {}}),  # Argo returns empty
+            ]
+            auth.refresh_access_token()
+        # AT stays unchanged since Argo returned nothing
+        assert auth._access_token == "CURRENT"
+        assert any("at_unchanged_after_ping" in r.message for r in caplog.records)
+
+    def test_apply_fresh_at_with_no_at_in_creds(self, caplog):
+        """_apply_fresh_at with no AT in creds dict logs at_unchanged_after_ping."""
+        auth = _make_auth()
+        auth._access_token = "OLD"
+        with patch.dict("os.environ", ARGO_ENV), \
+             caplog.at_level("WARNING"):
+            auth._apply_fresh_at({}, "42")
+        assert auth._access_token == "OLD"  # unchanged
+        assert any("at_unchanged_after_ping" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

`SalesforceAuthOAuth.login()` called SF's OAuth token endpoint directly, discarding the returned `refresh_token` and never writing back to Argo. With SF RTR enabled, the 15-min timer retried with a revoked RT → `invalid_grant`. Argo held the dead RT, so mk-push/mk-pull/mk-bongo also broke on their next refresh for the same tenant.

## Solution

The tap is now a **pure credential consumer** — it never calls SF OAuth. All token rotation is delegated to services that already implement the RTR-safe lock protocol.

### Two-path design

**Timer path** (`_sync_from_argo`, every 15 min)
- `GET /v1/tenant/{tenant}/connectors/salesforce` from Argo → sets `_access_token` + `_instance_url`
- No SF call, no lock. Picks up tokens rotated by mk-push/mk-pull/mk-bongo automatically.

**401 path** (`refresh_access_token`, on expired AT)
- `GET bongo /v1/org/{tenant}/integrations/salesforce/ping`
- Bongo triggers `lockAwareRefreshFn` (mk-node-libs): lock → re-read → SF OAuth → Argo persist
- Tap re-reads fresh AT from Argo and retries
- Tap **never calls SF OAuth** → zero RTR risk

### Fail-fast startup

`parse_credentials()` validates all 5 required env vars at startup — raises `RuntimeError` listing the missing ones before any sync begins.

### 401 guard for password-auth tenants

`_make_request` gates the refresh+retry on `hasattr(self.auth, "refresh_access_token")` — password-auth sessions (`SalesforceAuthPassword`) don't have this method and 401s propagate normally.

## Reviewer Q&A

**"Will this mark the refresh token as invalid when an admin refreshes via Argo?"** (rmueller)
No. Admin-triggered refreshes go through bongo/Argo's own `lockAwareRefreshFn`. The tap only reads the resulting AT from Argo — it never sends a refresh token to SF, so it cannot invalidate anything.

**"Will this risk issues for other services using refresh tokens?"** (richard-merrick)
No. The tap has zero contact with the refresh token: `grep -rn "oauth2/token"` across `tap_salesforce/` returns nothing. RT rotation is owned exclusively by node services (mk-push, mk-pull, mk-bongo) via the distributed lock. The tap adopts whatever AT they write to Argo.

**"Should we use tenacity for retries?"** (richard-merrick)
`_make_request` already uses `backoff` (exponential, max 10 tries) for connection errors. The 401 AT-expiry retry is a single explicit retry — deliberately not a backoff loop, because a 401 is an auth failure that resolves in one round trip (ping bongo → read Argo → retry), not a transient network error.

## Removed

`SIMULATOR_TAP_SALESFORCE_LOGIN_URL` — previously overrode the SF OAuth token URL for local testing. Now dead: the tap never calls SF OAuth, so there is no URL to simulate. Replace local test setups with the `validate_bongo_refresh.py` script against staging.

`TAP_SALESFORCE_REFRESH_TOKEN`, `TAP_SALESFORCE_CLIENT_ID`, `TAP_SALESFORCE_CLIENT_SECRET` — all credentials come from Argo at runtime.

## Required env vars (ECS task)

| Var | Airflow Variable | Purpose |
|---|---|---|
| `ARGO_URL` | `argo_url` | Argo base URL |
| `TENANT` | _(from tenant config)_ | Tenant ID |
| `ARGO_CONNECTOR_API_KEY` | `argo_connector_api_key` | Argo Basic auth key |
| `BONGO_API_TARGET_URL` | `bongo_api_target_url` | Bongo base URL |
| `BONGO_API_BASIC_AUTH_USERNAME` | `bongo_api_basic_auth_username` | Bongo UUID (same as hg-force-api) |

## RTR safety proof

`grep -rn "oauth2/token"` across `tap_salesforce/` → zero results. `self._credentials.refresh_token` is always `""` and is never read. The RT never passes through the tap process.

## Companion PR

[mk-airflow #925](https://github.com/HGData/mk-airflow/pull/925) — adds env vars to ECS task, removes stale SF credential vars.

## Validated against staging (tenant 426087, sandbox)

- ✓ Fail-fast: each of 5 missing vars raises `RuntimeError` naming the missing one
- ✓ Startup: `parse_credentials → auth.login() → _sync_from_argo` reads AT from Argo, SF query 200
- ✓ password-auth guard: `hasattr` correctly absent on `SalesforceAuthPassword`
- ✓ 401 detection: `_is_session_expired` correctly classifies all cases; `_rebuild_headers_with_new_at` covers all header types
- ✓ 401 recovery: expired AT → bongo ping → fresh AT → SF 200
- ✓ Concurrent (6 pods): all converge on same AT, all SF queries succeed

## Tests

21 tests: `parse_credentials` fail-fast (4 missing-var parametrize + error message content), timer sync, 401 refresh, exact Basic auth header format for Argo and Bongo, `tested=false` handling, error logging.