### PR TITLE
(RGI-1724) fix: fill gap in bulk operator with operation_too_large handling for SF tasks

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -232,8 +232,10 @@ def _do_discover_impl(sf: Salesforce, streams: list[str]):  # noqa: C901
 
                 property_schema, mdata = create_property_schema(f, mdata)
 
-                # Compound Address fields cannot be queried by the Bulk API
-                if f["type"] in ("address", "location") and sf.api_type in [
+                # Compound Address fields cannot be queried by the Bulk API. Use the
+                # per-stream effective api_type so a stream routed to BULK via an
+                # override drops these fields even when the global type is REST.
+                if f["type"] in ("address", "location") and sf.effective_api_type(sobject_name) in [
                     tap_salesforce.salesforce.BULK_API_TYPE,
                     tap_salesforce.salesforce.BULK2_API_TYPE,
                 ]:
@@ -249,10 +251,13 @@ def _do_discover_impl(sf: Salesforce, streams: list[str]):  # noqa: C901
                         )
                     )
 
-                # Blacklisted fields are dependent on the api_type being used
+                # Blacklisted fields depend on the api_type used; resolve the
+                # per-stream effective type so overridden streams are evaluated
+                # against the api_type they will actually be queried with.
+                blacklisted_fields = sf.get_blacklisted_fields(sf.effective_api_type(sobject_name))
                 field_pair = (sobject_name, field_name)
-                if field_pair in sf.get_blacklisted_fields():
-                    unsupported_fields.add((field_name, sf.get_blacklisted_fields()[field_pair]))
+                if field_pair in blacklisted_fields:
+                    unsupported_fields.add((field_name, blacklisted_fields[field_pair]))
 
                 inclusion = metadata.get(mdata, ("properties", field_name), "inclusion")
 
@@ -583,6 +588,7 @@ def main_impl():
             select_fields_by_default=CONFIG.get("select_fields_by_default"),
             default_start_date=CONFIG.get("start_date"),
             api_type=CONFIG.get("api_type"),
+            api_type_overrides=CONFIG.get("api_type_overrides"),
             limit_windowed_objects_month=CONFIG.get("limit_windowed_objects_month"),
             pull_config_objects=CONFIG.get("OBJECTS"),
         )

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -236,11 +236,16 @@ class Salesforce:
         select_fields_by_default=None,
         default_start_date=None,
         api_type=None,
+        api_type_overrides=None,
         windowed_objects=None,
         limit_windowed_objects_month=None,
         pull_config_objects=None,
     ):
         self.api_type = api_type.upper() if api_type else None
+        # Optional per-stream api_type overrides, e.g. {"Task": "BULK"} to route a
+        # high-volume Activity object through the Bulk API (with PK chunking) while
+        # the remaining streams stay on the global api_type.
+        self.api_type_overrides = self._normalize_api_type_overrides(api_type_overrides)
         self.session = requests.Session()
         if isinstance(quota_percent_per_run, str) and quota_percent_per_run.strip() == "":
             quota_percent_per_run = None
@@ -649,20 +654,50 @@ class Salesforce:
         else:
             return query
 
+    @staticmethod
+    def _normalize_api_type_overrides(api_type_overrides):
+        """Validate and normalize the per-stream api_type override map.
+
+        Keys are lowercased for case-insensitive stream matching (mirrors the Task
+        special-casing in rest.py/bulk.py); values are uppercased and validated
+        against the known api_types so a typo fails loudly at init rather than
+        silently falling back to the global type.
+        """
+        normalized_overrides = {}
+        for stream, value in (api_type_overrides or {}).items():
+            normalized = value.upper() if isinstance(value, str) else value
+            if normalized not in (REST_API_TYPE, BULK_API_TYPE, BULK2_API_TYPE):
+                raise TapSalesforceExceptionError(
+                    f"api_type_overrides[{stream!r}] must be one of "
+                    f"{[REST_API_TYPE, BULK_API_TYPE, BULK2_API_TYPE]}, got {value!r}"
+                )
+            normalized_overrides[stream.lower()] = normalized
+        return normalized_overrides
+
+    def effective_api_type(self, stream):
+        """Resolve the api_type for a stream, honoring per-stream overrides."""
+        return self.api_type_overrides.get(stream.lower(), self.api_type)
+
     def query(self, catalog_entry, state):
-        if self.api_type == BULK_API_TYPE:
+        api_type = self.effective_api_type(catalog_entry["stream"])
+        if api_type == BULK_API_TYPE:
             bulk = Bulk(self)
             return bulk.query(catalog_entry, state)
-        elif self.api_type == BULK2_API_TYPE:
+        elif api_type == BULK2_API_TYPE:
             bulk = Bulk2(self)
             return bulk.query(catalog_entry, state)
-        elif self.api_type == REST_API_TYPE:
+        elif api_type == REST_API_TYPE:
             rest = Rest(self)
             return rest.query(catalog_entry, state)
         else:
-            raise TapSalesforceExceptionError(f"api_type should be REST or BULK was: {self.api_type}")
+            raise TapSalesforceExceptionError(f"api_type should be REST or BULK was: {api_type}")
 
     def get_blacklisted_objects(self):
+        # Keyed off the global api_type only. Per-stream overrides are supported in
+        # the REST->BULK direction (the REST object blacklist is a subset of BULK's,
+        # so nothing an override targets gets wrongly excluded from discovery). The
+        # reverse (global BULK, override a BULK-unsupported object to REST) is not
+        # supported: the object would be filtered out here before the override runs.
         if self.api_type in [BULK_API_TYPE, BULK2_API_TYPE]:
             return UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS.union(QUERY_RESTRICTED_SALESFORCE_OBJECTS).union(
                 QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS
@@ -673,15 +708,18 @@ class Salesforce:
             raise TapSalesforceExceptionError(f"api_type should be REST or BULK was: {self.api_type}")
 
     # pylint: disable=line-too-long
-    def get_blacklisted_fields(self):
-        if self.api_type == BULK_API_TYPE or self.api_type == BULK2_API_TYPE:
+    def get_blacklisted_fields(self, api_type=None):
+        # Accepts an explicit api_type so discovery can pass the per-stream effective
+        # type (see effective_api_type); defaults to the global type otherwise.
+        api_type = api_type or self.api_type
+        if api_type == BULK_API_TYPE or api_type == BULK2_API_TYPE:
             return {
                 (
                     "EntityDefinition",
                     "RecordTypesSupported",
                 ): "this field is unsupported by the Bulk API."
             }
-        elif self.api_type == REST_API_TYPE:
+        elif api_type == REST_API_TYPE:
             return {}
         else:
-            raise TapSalesforceExceptionError(f"api_type should be REST or BULK was: {self.api_type}")
+            raise TapSalesforceExceptionError(f"api_type should be REST or BULK was: {api_type}")

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -109,7 +109,13 @@ class Bulk:
         batch_status = self._poll_on_batch_status(job_id, batch_id)
 
         if batch_status["state"] == "Failed":
-            if "QUERY_TIMEOUT" in batch_status["stateMessage"]:
+            state_message = batch_status["stateMessage"]
+            # A batch too large to process in one shot can still succeed once PK
+            # chunking splits it into bounded Id-range sub-batches. This covers a
+            # slow query (QUERY_TIMEOUT) as well as an Activity object breaching
+            # Salesforce's 100k-distinct-who/what limit (OPERATION_TOO_LARGE),
+            # which no date-window narrowing can escape but Id chunking can.
+            if "QUERY_TIMEOUT" in state_message or "OPERATION_TOO_LARGE" in state_message:
                 batch_status = self._bulk_query_with_pk_chunking(catalog_entry, start_date)
                 job_id = batch_status["job_id"]
 
@@ -136,7 +142,7 @@ class Bulk:
                     )
                     tap_output.write_state(state)
             else:
-                raise TapSalesforceExceptionError(batch_status["stateMessage"])
+                raise TapSalesforceExceptionError(state_message)
         else:
             for result in self.get_batch_results(job_id, batch_id, catalog_entry):
                 yield result
@@ -160,10 +166,18 @@ class Bulk:
 
         return batch_status
 
+    @staticmethod
+    def _job_operation(stream):
+        # Use `query` (not `queryAll`) for Task so soft-deleted/archived Activity
+        # rows are excluded, mirroring the REST path (see rest.py). Their
+        # WhoId/WhatId would otherwise count toward the 100k-distinct-who/what
+        # limit. PK chunking still bounds each sub-batch regardless.
+        return "query" if stream.lower() == "task" else "queryAll"
+
     def _create_job(self, catalog_entry, pk_chunking=False):
         url = self.bulk_url.format(self.sf.instance_url, "job")
         body = {
-            "operation": "queryAll",
+            "operation": self._job_operation(catalog_entry["stream"]),
             "object": catalog_entry["stream"],
             "contentType": "CSV",
         }

--- a/tap_salesforce/salesforce/bulk2.py
+++ b/tap_salesforce/salesforce/bulk2.py
@@ -36,6 +36,10 @@ class Bulk2:
 
         query = self.sf._build_query_string(catalog_entry, start_date, order_by_clause=False)
 
+        # NOTE: Bulk2 has no PK-chunking fallback and always uses `queryAll`, so it
+        # does not get the Task-specific handling that Bulk (v1) has. Routing Task
+        # to BULK2 via api_type_overrides would hit the same OPERATION_TOO_LARGE
+        # (100k-distinct-who/what) this repo works around; use BULK for Task.
         body = {
             "operation": "queryAll",
             "query": query,

--- a/tests/test_api_type_overrides.py
+++ b/tests/test_api_type_overrides.py
@@ -1,0 +1,117 @@
+"""Unit tests for per-stream api_type overrides + Task Bulk operation handling.
+
+Changes covered:
+- api_type_overrides validation/normalization (case-insensitive keys, uppercased
+  and validated values)
+- Salesforce.effective_api_type() resolution (override wins, else global)
+- Salesforce.query() routes per-stream (Task -> Bulk, others -> global Rest)
+- Bulk._job_operation() picks `query` for Task, `queryAll` otherwise
+
+Run with:
+    pytest tests/test_api_type_overrides.py -v
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tap_salesforce.salesforce import (
+    BULK_API_TYPE,
+    BULK2_API_TYPE,
+    REST_API_TYPE,
+    Salesforce,
+)
+from tap_salesforce.salesforce.bulk import Bulk
+from tap_salesforce.salesforce.exceptions import TapSalesforceExceptionError
+
+
+def make_sf(api_type=REST_API_TYPE, api_type_overrides=None):
+    """Build a minimal Salesforce instance without network calls."""
+    sf = Salesforce.__new__(Salesforce)
+    sf.api_type = api_type
+    sf.api_type_overrides = Salesforce._normalize_api_type_overrides(api_type_overrides)
+    return sf
+
+
+def catalog_entry(stream):
+    return {"stream": stream, "tap_stream_id": stream, "metadata": []}
+
+
+# ---------------------------------------------------------------------------
+# 1. _normalize_api_type_overrides
+# ---------------------------------------------------------------------------
+
+class TestNormalizeApiTypeOverrides:
+    def test_none_yields_empty_map(self):
+        assert Salesforce._normalize_api_type_overrides(None) == {}
+
+    def test_keys_lowercased_values_uppercased(self):
+        result = Salesforce._normalize_api_type_overrides({"Task": "bulk"})
+        assert result == {"task": BULK_API_TYPE}
+
+    def test_all_valid_api_types_accepted(self):
+        result = Salesforce._normalize_api_type_overrides(
+            {"Task": "BULK", "Event": "bulk2", "Lead": "rest"}
+        )
+        assert result == {"task": BULK_API_TYPE, "event": BULK2_API_TYPE, "lead": REST_API_TYPE}
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(TapSalesforceExceptionError):
+            Salesforce._normalize_api_type_overrides({"Task": "BLUK"})
+
+
+# ---------------------------------------------------------------------------
+# 2. effective_api_type
+# ---------------------------------------------------------------------------
+
+class TestEffectiveApiType:
+    def test_override_wins(self):
+        sf = make_sf(api_type=REST_API_TYPE, api_type_overrides={"Task": "BULK"})
+        assert sf.effective_api_type("Task") == BULK_API_TYPE
+
+    def test_override_lookup_is_case_insensitive(self):
+        sf = make_sf(api_type=REST_API_TYPE, api_type_overrides={"task": "BULK"})
+        assert sf.effective_api_type("Task") == BULK_API_TYPE
+        assert sf.effective_api_type("TASK") == BULK_API_TYPE
+
+    def test_falls_back_to_global_for_unlisted_stream(self):
+        sf = make_sf(api_type=REST_API_TYPE, api_type_overrides={"Task": "BULK"})
+        assert sf.effective_api_type("Lead") == REST_API_TYPE
+
+
+# ---------------------------------------------------------------------------
+# 3. query() routing
+# ---------------------------------------------------------------------------
+
+class TestQueryRouting:
+    def test_task_routes_to_bulk_others_to_global(self):
+        sf = make_sf(api_type=REST_API_TYPE, api_type_overrides={"Task": "BULK"})
+        state = {}
+
+        with patch("tap_salesforce.salesforce.Bulk") as mock_bulk, patch(
+            "tap_salesforce.salesforce.Rest"
+        ) as mock_rest:
+            sf.query(catalog_entry("Task"), state)
+            mock_bulk.assert_called_once_with(sf)
+            mock_rest.assert_not_called()
+
+        with patch("tap_salesforce.salesforce.Bulk") as mock_bulk, patch(
+            "tap_salesforce.salesforce.Rest"
+        ) as mock_rest:
+            sf.query(catalog_entry("Lead"), state)
+            mock_rest.assert_called_once_with(sf)
+            mock_bulk.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4. Bulk._job_operation
+# ---------------------------------------------------------------------------
+
+class TestBulkJobOperation:
+    @pytest.mark.parametrize("stream", ["Task", "task", "TASK"])
+    def test_task_uses_query(self, stream):
+        assert Bulk._job_operation(stream) == "query"
+
+    @pytest.mark.parametrize("stream", ["Lead", "Account", "Event", "Opportunity"])
+    def test_non_task_uses_query_all(self, stream):
+        assert Bulk._job_operation(stream) == "queryAll"


### PR DESCRIPTION
https://hgdata.atlassian.net/browse/RGI-1724

- PK chunking on OPERATION_TOO_LARGE error, (previously just on QUERY_TIMEOUT): fixes Task's 100k who/what limit
- Per-stream api_type_overrides; Task→BULK, rest REST as only Task needs Bulk by default
- Discovery/blacklists respect per-stream type: avoid selecting Bulk-incompatible fields
