### PR TITLE
(RGI-1724) fix: handle cases where bulk api can't access /limit endpoint; conditionally switch to bulk for task stream

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -10,7 +10,9 @@ import singer.utils as singer_utils
 from singer import metadata, metrics
 
 from tap_salesforce.observability import (
+    dogstatsd_count,
     emit_describe_call_metric,
+    get_tenant_id,
     log_api_call,
     log_describe_call,
     log_quota_status,
@@ -21,6 +23,7 @@ from tap_salesforce.salesforce.credentials import SalesforceAuth
 from tap_salesforce.salesforce.exceptions import (
     SFDCCustomNotAcceptableError,
     TapSalesforceExceptionError,
+    TapSalesforceOperationTooLargeError,
     TapSalesforceQuotaExceededError,
 )
 from tap_salesforce.salesforce.rest import Rest
@@ -679,6 +682,10 @@ class Salesforce:
         return self.api_type_overrides.get(stream.lower(), self.api_type)
 
     def query(self, catalog_entry, state):
+        # Reset per stream: the Bulk path sets pk_chunking mid-iteration and sync
+        # reads it afterwards to change bookmark handling. Without resetting here it
+        # would leak to later REST streams and corrupt their bookmarks.
+        self.pk_chunking = False
         api_type = self.effective_api_type(catalog_entry["stream"])
         if api_type == BULK_API_TYPE:
             bulk = Bulk(self)
@@ -687,10 +694,61 @@ class Salesforce:
             bulk = Bulk2(self)
             return bulk.query(catalog_entry, state)
         elif api_type == REST_API_TYPE:
-            rest = Rest(self)
-            return rest.query(catalog_entry, state)
+            return self._rest_query_with_bulk_fallback(catalog_entry, state)
         else:
             raise TapSalesforceExceptionError(f"api_type should be REST or BULK was: {api_type}")
+
+    def _rest_query_with_bulk_fallback(self, catalog_entry, state):
+        """Query via REST, escalating to the Bulk API if REST exhausts date-range
+        bisection on a too-large/timeout error. Falls back only when no records have
+        been emitted yet; once records are streamed to the target, re-querying via
+        Bulk would duplicate them, so the error is surfaced instead."""
+        stream = catalog_entry["stream"]
+        emitted = False
+        try:
+            for record in Rest(self).query(catalog_entry, state):
+                emitted = True
+                yield record
+        except TapSalesforceOperationTooLargeError as ex:
+            if emitted:
+                # Records from earlier bisected windows were already streamed and the
+                # bookmark advanced, so escalating mid-stream would duplicate them.
+                # Fail this run; it self-heals on the next one, which resumes from the
+                # advanced bookmark with the un-bisectable window first (emitted
+                # == False) and escalates to Bulk then. This failed-run-then-recover
+                # is expected behavior, not a defect.
+                LOGGER.warning(
+                    "REST query for %s hit %s after emitting records, so this run will "
+                    "fail. This is expected and self-heals on the next run: it resumes "
+                    "from the advanced bookmark at the un-bisectable window and escalates "
+                    "to the Bulk API (PK chunking) from there.",
+                    stream,
+                    ex,
+                )
+                raise
+            if stream in UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS:
+                # The Bulk API cannot query this object (e.g. Activity-relationship
+                # objects like TaskWhoRelation), so escalating would fail at Bulk job
+                # creation with a confusing error. Surface the clear REST error.
+                LOGGER.warning(
+                    "REST query for %s hit %s, but the object is not Bulk-queryable; "
+                    "cannot escalate to the Bulk API. Surfacing the original error.",
+                    stream,
+                    ex,
+                )
+                raise
+            LOGGER.warning(
+                "REST query for %s exhausted date-range bisection (%s); "
+                "falling back to the Bulk API with PK chunking.",
+                stream,
+                ex,
+            )
+            dogstatsd_count(
+                "mdi.salesforce.api.rest_bulk_fallback",
+                1,
+                {"stream": stream, "tenant": get_tenant_id()},
+            )
+            yield from Bulk(self).query(catalog_entry, state)
 
     def get_blacklisted_objects(self):
         # Keyed off the global api_type only. Per-stream overrides are supported in

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -264,7 +264,11 @@ class Salesforce:
         self.rest_requests_attempted = 0
         self.jobs_completed = 0
         self.data_url = "{}/services/data/v60.0/{}"
-        self.pk_chunking = False
+        # PK-chunking is tracked per stream, not as a single flag: do_sync runs all
+        # streams concurrently against this shared Salesforce instance, so a global
+        # flag set by one stream's Bulk sync would corrupt the end-of-stream bookmark
+        # logic of any concurrent REST stream (and vice versa).
+        self._pk_chunking_streams = set()
 
         # Quota tracking for before/after extraction monitoring
         self._initial_quota_used = None
@@ -681,11 +685,18 @@ class Salesforce:
         """Resolve the api_type for a stream, honoring per-stream overrides."""
         return self.api_type_overrides.get(stream.lower(), self.api_type)
 
+    def mark_pk_chunking(self, tap_stream_id):
+        """Record that a stream is being synced via Bulk PK chunking (per stream so it
+        is safe under the concurrent stream syncs in do_sync)."""
+        self._pk_chunking_streams.add(tap_stream_id)
+
+    def is_pk_chunking(self, tap_stream_id):
+        return tap_stream_id in self._pk_chunking_streams
+
     def query(self, catalog_entry, state):
-        # Reset per stream: the Bulk path sets pk_chunking mid-iteration and sync
-        # reads it afterwards to change bookmark handling. Without resetting here it
-        # would leak to later REST streams and corrupt their bookmarks.
-        self.pk_chunking = False
+        # Clear any stale PK-chunking mark for this stream before querying; the Bulk
+        # path re-marks it mid-iteration if it chunks.
+        self._pk_chunking_streams.discard(catalog_entry["tap_stream_id"])
         api_type = self.effective_api_type(catalog_entry["stream"])
         if api_type == BULK_API_TYPE:
             bulk = Bulk(self)

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -7,7 +7,7 @@ import time
 
 import singer
 import xmltodict
-from requests.exceptions import RequestException
+from requests.exceptions import HTTPError, RequestException
 from singer import metrics
 
 from tap_salesforce import output as tap_output
@@ -22,6 +22,19 @@ ITER_CHUNK_SIZE = 1024
 DEFAULT_CHUNK_SIZE = 50000
 
 LOGGER = singer.get_logger()
+
+
+def _error_code(response):
+    """Best-effort extraction of the Salesforce errorCode from an error response."""
+    try:
+        body = response.json()
+    except (ValueError, AttributeError):
+        return None
+    if isinstance(body, list) and body:
+        return body[0].get("errorCode")
+    if isinstance(body, dict):
+        return body.get("errorCode")
+    return None
 
 
 # pylint: disable=inconsistent-return-statements
@@ -61,8 +74,25 @@ class Bulk:
         endpoint = "limits"
         url = self.sf.data_url.format(self.sf.instance_url, endpoint)
 
-        with metrics.http_request_timer(endpoint):
-            resp = self.sf._make_request("GET", url, headers=self.sf.auth.rest_headers).json()
+        try:
+            with metrics.http_request_timer(endpoint):
+                resp = self.sf._make_request("GET", url, headers=self.sf.auth.rest_headers).json()
+        except HTTPError as ex:
+            # Some orgs have the /limits resource disabled (API_DISABLED_FOR_ORG,
+            # delivered as HTTP 403). The quota check is best-effort, so skip it
+            # rather than failing the whole sync when limits are unreadable. The REST
+            # path never hit this because it does not call /limits.
+            #
+            # Match only this specific errorCode, NOT any 403: other 403s
+            # (REQUEST_LIMIT_EXCEEDED, INSUFFICIENT_ACCESS, ...) are real problems that
+            # should surface rather than silently proceed into a Bulk job.
+            if _error_code(ex.response) == "API_DISABLED_FOR_ORG":
+                LOGGER.warning(
+                    "Skipping Bulk API quota pre-check: /limits disabled for org "
+                    "(API_DISABLED_FOR_ORG). Proceeding without it."
+                )
+                return
+            raise
 
         quota_max = resp["DailyBulkApiBatches"]["Max"]
         max_requests_for_run = int((self.sf.quota_percent_per_run * quota_max) / 100)

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -30,7 +30,7 @@ def _error_code(response):
         body = response.json()
     except (ValueError, AttributeError):
         return None
-    if isinstance(body, list) and body:
+    if isinstance(body, list) and body and isinstance(body[0], dict):
         return body[0].get("errorCode")
     if isinstance(body, dict):
         return body.get("errorCode")
@@ -149,8 +149,8 @@ class Bulk:
                 batch_status = self._bulk_query_with_pk_chunking(catalog_entry, start_date)
                 job_id = batch_status["job_id"]
 
-                # Set pk_chunking to True to indicate that we should write a bookmark differently
-                self.sf.pk_chunking = True
+                # Mark this stream as PK-chunking so sync writes its bookmark differently
+                self.sf.mark_pk_chunking(catalog_entry["tap_stream_id"])
 
                 # Add the bulk Job ID and its batches to the state so it can be resumed if necessary
                 tap_stream_id = catalog_entry["tap_stream_id"]

--- a/tap_salesforce/salesforce/exceptions.py
+++ b/tap_salesforce/salesforce/exceptions.py
@@ -9,6 +9,15 @@ class TapSalesforceQuotaExceededError(TapSalesforceExceptionError):
     pass
 
 
+class TapSalesforceOperationTooLargeError(TapSalesforceExceptionError):
+    """A REST query could not be satisfied even after date-range bisection
+    (OPERATION_TOO_LARGE / QUERY_TIMEOUT). Signals that the stream should be
+    retried via the Bulk API with PK chunking, which is not subject to the same
+    limits (e.g. the Activity 100k-distinct-who/what ceiling)."""
+
+    pass
+
+
 class SFDCCustomNotAcceptableError(Exception):
     """
     SFDC returned CustomNotAcceptable error with HTTP Error code 406.

--- a/tap_salesforce/salesforce/rest.py
+++ b/tap_salesforce/salesforce/rest.py
@@ -4,7 +4,10 @@ import singer.utils as singer_utils
 from singer import metadata as singer_metadata
 from requests.exceptions import HTTPError
 
-from tap_salesforce.salesforce.exceptions import TapSalesforceExceptionError
+from tap_salesforce.salesforce.exceptions import (
+    TapSalesforceExceptionError,
+    TapSalesforceOperationTooLargeError,
+)
 
 LOGGER = singer.get_logger()
 
@@ -41,7 +44,10 @@ class Rest:
             end_date = sync_start
 
         if retries == 0:
-            raise TapSalesforceExceptionError(
+            # Exhausted date-range bisection for a retryable error (OPERATION_TOO_LARGE
+            # / QUERY_TIMEOUT). Signal the caller to escalate this stream to the Bulk
+            # API (PK chunking), which the REST bisection cannot substitute for.
+            raise TapSalesforceOperationTooLargeError(
                 "Ran out of retries attempting to query Salesforce Object {}".format(catalog_entry["stream"])
             )
 
@@ -114,7 +120,9 @@ class Rest:
                 end_date = end_date - half_range
 
                 if half_range.total_seconds() < 3600:
-                    raise TapSalesforceExceptionError(
+                    # Cannot bisect below the 1-hour floor and the window is still
+                    # too large; escalate this stream to the Bulk API (PK chunking).
+                    raise TapSalesforceOperationTooLargeError(
                         "Attempting to query by less than 1 hour range, this would cause infinite looping."
                     )
 

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -146,7 +146,7 @@ def sync_records(sf, catalog_entry, state, counter, state_msg_threshold):
 
         replication_key_value = replication_key and singer_utils.strptime_with_tz(rec[replication_key])
 
-        if sf.pk_chunking:
+        if sf.is_pk_chunking(catalog_entry["tap_stream_id"]):
             if (
                 replication_key_value
                 and replication_key_value <= start_time
@@ -189,8 +189,8 @@ def sync_records(sf, catalog_entry, state, counter, state_msg_threshold):
         tap_output.write_message(activate_version_message)
         state = singer.write_bookmark(state, catalog_entry["tap_stream_id"], "version", None)
 
-    # If pk_chunking is set, only write a bookmark at the end
-    if sf.pk_chunking:
+    # If this stream was PK-chunked, only write a bookmark at the end
+    if sf.is_pk_chunking(catalog_entry["tap_stream_id"]):
         # Write a bookmark with the highest value we've seen
         state = singer.write_bookmark(
             state,

--- a/tests/test_api_type_overrides.py
+++ b/tests/test_api_type_overrides.py
@@ -35,6 +35,7 @@ def make_sf(api_type=REST_API_TYPE, api_type_overrides=None):
     sf = Salesforce.__new__(Salesforce)
     sf.api_type = api_type
     sf.api_type_overrides = Salesforce._normalize_api_type_overrides(api_type_overrides)
+    sf._pk_chunking_streams = set()
     return sf
 
 
@@ -109,13 +110,21 @@ class TestQueryRouting:
             mock_rest.assert_called_once_with(sf)
             mock_bulk.assert_not_called()
 
-    def test_query_resets_pk_chunking(self):
+    def test_query_clears_stale_pk_chunking_mark(self):
         sf = make_sf()
-        sf.pk_chunking = True
+        sf.mark_pk_chunking("Lead")
         with patch("tap_salesforce.salesforce.Rest") as mock_rest:
             mock_rest.return_value.query.return_value = iter([])
             list(sf.query(catalog_entry("Lead"), {}))
-        assert sf.pk_chunking is False
+        assert sf.is_pk_chunking("Lead") is False
+
+    def test_pk_chunking_is_tracked_per_stream(self):
+        # One stream chunking must not leak to a concurrent stream (do_sync runs
+        # all streams against one shared Salesforce instance).
+        sf = make_sf()
+        sf.mark_pk_chunking("Task")
+        assert sf.is_pk_chunking("Task") is True
+        assert sf.is_pk_chunking("Lead") is False
 
 
 # ---------------------------------------------------------------------------
@@ -243,6 +252,11 @@ class TestErrorCode:
     def test_none_on_unparseable(self):
         resp = Mock()
         resp.json.side_effect = ValueError("no json")
+        assert _error_code(resp) is None
+
+    def test_none_on_list_of_non_dicts(self):
+        resp = Mock()
+        resp.json.return_value = ["oops"]
         assert _error_code(resp) is None
 
 

--- a/tests/test_api_type_overrides.py
+++ b/tests/test_api_type_overrides.py
@@ -11,9 +11,11 @@ Run with:
     pytest tests/test_api_type_overrides.py -v
 """
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
+from requests.exceptions import HTTPError
 
 from tap_salesforce.salesforce import (
     BULK_API_TYPE,
@@ -21,8 +23,11 @@ from tap_salesforce.salesforce import (
     REST_API_TYPE,
     Salesforce,
 )
-from tap_salesforce.salesforce.bulk import Bulk
-from tap_salesforce.salesforce.exceptions import TapSalesforceExceptionError
+from tap_salesforce.salesforce.bulk import Bulk, _error_code
+from tap_salesforce.salesforce.exceptions import (
+    TapSalesforceExceptionError,
+    TapSalesforceOperationTooLargeError,
+)
 
 
 def make_sf(api_type=REST_API_TYPE, api_type_overrides=None):
@@ -84,23 +89,161 @@ class TestEffectiveApiType:
 # ---------------------------------------------------------------------------
 
 class TestQueryRouting:
-    def test_task_routes_to_bulk_others_to_global(self):
+    def test_override_routes_to_bulk(self):
         sf = make_sf(api_type=REST_API_TYPE, api_type_overrides={"Task": "BULK"})
-        state = {}
-
         with patch("tap_salesforce.salesforce.Bulk") as mock_bulk, patch(
             "tap_salesforce.salesforce.Rest"
         ) as mock_rest:
-            sf.query(catalog_entry("Task"), state)
+            mock_bulk.return_value.query.return_value = iter([])
+            list(sf.query(catalog_entry("Task"), {}))
             mock_bulk.assert_called_once_with(sf)
             mock_rest.assert_not_called()
 
+    def test_rest_stream_uses_rest(self):
+        sf = make_sf(api_type=REST_API_TYPE, api_type_overrides={"Task": "BULK"})
         with patch("tap_salesforce.salesforce.Bulk") as mock_bulk, patch(
             "tap_salesforce.salesforce.Rest"
         ) as mock_rest:
-            sf.query(catalog_entry("Lead"), state)
+            mock_rest.return_value.query.return_value = iter([])
+            list(sf.query(catalog_entry("Lead"), {}))
             mock_rest.assert_called_once_with(sf)
             mock_bulk.assert_not_called()
+
+    def test_query_resets_pk_chunking(self):
+        sf = make_sf()
+        sf.pk_chunking = True
+        with patch("tap_salesforce.salesforce.Rest") as mock_rest:
+            mock_rest.return_value.query.return_value = iter([])
+            list(sf.query(catalog_entry("Lead"), {}))
+        assert sf.pk_chunking is False
+
+
+# ---------------------------------------------------------------------------
+# 5. REST -> Bulk fallback on OPERATION_TOO_LARGE
+# ---------------------------------------------------------------------------
+
+class TestRestBulkFallback:
+    def test_falls_back_to_bulk_when_rest_too_large_and_nothing_emitted(self):
+        sf = make_sf(api_type=REST_API_TYPE)
+
+        def rest_raises():
+            raise TapSalesforceOperationTooLargeError("boom")
+            yield  # pragma: no cover - marks this a generator
+
+        with patch("tap_salesforce.salesforce.Rest") as mock_rest, patch(
+            "tap_salesforce.salesforce.Bulk"
+        ) as mock_bulk:
+            mock_rest.return_value.query.return_value = rest_raises()
+            mock_bulk.return_value.query.return_value = iter([{"Id": "b1"}])
+            records = list(sf.query(catalog_entry("Task"), {}))
+        assert records == [{"Id": "b1"}]
+        mock_bulk.assert_called_once_with(sf)
+
+    def test_does_not_fall_back_after_records_emitted(self):
+        sf = make_sf(api_type=REST_API_TYPE)
+
+        def rest_emit_then_raise():
+            yield {"Id": "1"}
+            raise TapSalesforceOperationTooLargeError("boom")
+
+        with patch("tap_salesforce.salesforce.Rest") as mock_rest, patch(
+            "tap_salesforce.salesforce.Bulk"
+        ) as mock_bulk:
+            mock_rest.return_value.query.return_value = rest_emit_then_raise()
+            with pytest.raises(TapSalesforceOperationTooLargeError):
+                list(sf.query(catalog_entry("Task"), {}))
+            mock_bulk.assert_not_called()
+
+    def test_no_fallback_for_bulk_unsupported_object(self):
+        # TaskWhoRelation is REST-queryable but Bulk-unsupported; escalation would
+        # fail at Bulk job creation, so the original REST error must surface.
+        from tap_salesforce.salesforce import UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS
+
+        assert "TaskWhoRelation" in UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS
+        sf = make_sf(api_type=REST_API_TYPE)
+
+        def rest_raises():
+            raise TapSalesforceOperationTooLargeError("boom")
+            yield  # pragma: no cover - marks this a generator
+
+        with patch("tap_salesforce.salesforce.Rest") as mock_rest, patch(
+            "tap_salesforce.salesforce.Bulk"
+        ) as mock_bulk:
+            mock_rest.return_value.query.return_value = rest_raises()
+            with pytest.raises(TapSalesforceOperationTooLargeError):
+                list(sf.query(catalog_entry("TaskWhoRelation"), {}))
+            mock_bulk.assert_not_called()
+
+    def test_no_fallback_when_rest_succeeds(self):
+        sf = make_sf(api_type=REST_API_TYPE)
+        with patch("tap_salesforce.salesforce.Rest") as mock_rest, patch(
+            "tap_salesforce.salesforce.Bulk"
+        ) as mock_bulk:
+            mock_rest.return_value.query.return_value = iter([{"Id": "1"}])
+            records = list(sf.query(catalog_entry("Lead"), {}))
+        assert records == [{"Id": "1"}]
+        mock_bulk.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 6. Bulk quota check tolerates disabled /limits
+# ---------------------------------------------------------------------------
+
+def _fake_sf_for_quota(make_request):
+    return SimpleNamespace(
+        data_url="{}/services/data/v60.0/{}",
+        instance_url="https://x.my.salesforce.com",
+        auth=SimpleNamespace(rest_headers={}),
+        _make_request=make_request,
+        quota_percent_total=95,
+        quota_percent_per_run=25,
+        jobs_completed=0,
+    )
+
+
+def _http_error(status_code, body):
+    resp = Mock()
+    resp.status_code = status_code
+    resp.json.return_value = body
+    return HTTPError(response=resp)
+
+
+class TestCheckBulkQuotaUsage:
+    def test_skips_on_api_disabled_for_org_403(self):
+        raiser = Mock(side_effect=_http_error(403, [{"errorCode": "API_DISABLED_FOR_ORG"}]))
+        bulk = Bulk(_fake_sf_for_quota(raiser))
+        assert bulk.check_bulk_quota_usage() is None  # no raise
+
+    def test_reraises_non_403_http_error(self):
+        raiser = Mock(side_effect=_http_error(500, [{"errorCode": "SERVER_ERROR"}]))
+        bulk = Bulk(_fake_sf_for_quota(raiser))
+        with pytest.raises(HTTPError):
+            bulk.check_bulk_quota_usage()
+
+    def test_reraises_other_403(self):
+        # A 403 that is NOT API_DISABLED_FOR_ORG (e.g. rate limit) must surface,
+        # not be swallowed into a Bulk job.
+        raiser = Mock(side_effect=_http_error(403, [{"errorCode": "REQUEST_LIMIT_EXCEEDED"}]))
+        bulk = Bulk(_fake_sf_for_quota(raiser))
+        with pytest.raises(HTTPError):
+            bulk.check_bulk_quota_usage()
+
+
+class TestErrorCode:
+    def test_parses_list_body(self):
+        resp = Mock()
+        resp.json.return_value = [{"errorCode": "API_DISABLED_FOR_ORG"}]
+        assert _error_code(resp) == "API_DISABLED_FOR_ORG"
+
+    def test_parses_dict_body(self):
+        resp = Mock()
+        resp.json.return_value = {"errorCode": "X"}
+        assert _error_code(resp) == "X"
+
+    def test_none_on_unparseable(self):
+        resp = Mock()
+        resp.json.side_effect = ValueError("no json")
+        assert _error_code(resp) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_race_bookmark.py
+++ b/tests/test_race_bookmark.py
@@ -304,7 +304,7 @@ class TestBookmarkLoading:
 
         # Mock Salesforce instance
         mock_sf = MagicMock()
-        mock_sf.pk_chunking = False
+        mock_sf.is_pk_chunking.return_value = False
         mock_sf.query.return_value = [
             {
                 "Id": "001",


### PR DESCRIPTION
https://hgdata.atlassian.net/jira/software/c/projects/RGI/boards/1235?selectedIssue=RGI-1724

For a small number of tenants the /limit API endpoint is not enabled.
The previous commit moved all Task extractions onto bulk even if the OPERATION_TOO_LARGE error was not surfaced.
This PR makes the switch to Bulk conditional on the REST API throwing the specific error, and gracefully handles missing /limit permissions.